### PR TITLE
feat: Add "Tax Exemption Reason" in Sales Tax Templates

### DIFF
--- a/erpnext_germany/hooks.py
+++ b/erpnext_germany/hooks.py
@@ -342,6 +342,26 @@ germany_custom_fields = {
 			"translatable": 0,
 		},
 	],
+	("Quotation", "Sales Order", "Sales Invoice"): [
+		{
+			"label": "Tax Exemption Reason",
+			"fieldtype": "Small Text",
+			"fieldname": "tax_exemption_reason",
+			"fetch_from": "taxes_and_charges.tax_exemption_reason",
+			"depends_on": "tax_exemption_reason",
+			"insert_after": "taxes_and_charges",
+			"translatable": 0,
+		}
+	],
+	"Sales Taxes and Charges Template": [
+		{
+			"label": "Tax Exemption Reason",
+			"fieldtype": "Small Text",
+			"fieldname": "tax_exemption_reason",
+			"insert_after": "tax_category",
+			"translatable": 0,
+		}
+	],
 }
 
 germany_property_setters = {

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -1,1 +1,2 @@
 execute:from erpnext_germany.install import after_install; after_install() # 7
+erpnext_germany.patches.add_tax_exemption_reason_fields

--- a/erpnext_germany/patches/add_tax_exemption_reason_fields.py
+++ b/erpnext_germany/patches/add_tax_exemption_reason_fields.py
@@ -1,0 +1,27 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+	create_custom_fields(
+		{
+			("Quotation", "Sales Order", "Sales Invoice"): [
+				{
+					"label": "Tax Exemption Reason",
+					"fieldtype": "Small Text",
+					"fieldname": "tax_exemption_reason",
+					"fetch_from": "taxes_and_charges.tax_exemption_reason",
+					"depends_on": "tax_exemption_reason",
+					"insert_after": "taxes_and_charges",
+					"translatable": 0,
+				},
+			],
+			"Sales Taxes and Charges Template": [
+				{
+					"label": "Tax Exemption Reason",
+					"fieldtype": "Small Text",
+					"fieldname": "tax_exemption_reason",
+					"insert_after": "tax_category",
+					"translatable": 0,
+				}
+			],
+		}
+	)

--- a/erpnext_germany/translations/de.csv
+++ b/erpnext_germany/translations/de.csv
@@ -15,3 +15,4 @@ Religious Denomination,Konfession
 Has Children,Hat Kinder
 Highest School Qualification,Höchster Schulabschluss
 Has Other Employments,Hat Nebenbeschäftigungen
+Tax Exemption Reason,Steuerbefreiungsgrund,


### PR DESCRIPTION
- Store "Tax Exemption Reason" in Sales Taxes and Charges Template
- Fetch this into Quotation, SO, and SI when template is selected
- Patch and `hooks` to add fields