### PR TITLE
feat: delete only most recent sales transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ App to hold regional code for Germany, built on top of ERPNext.
 
     Automatically checks the validity of EU VAT IDs of all your customers every three months, or manually whenever you want. Check out the [intro on Youtube](https://youtu.be/hsFMn2Y85zA) (german).
 
-   ![Validate EU VAT ID](docs/vat_check.png)
+    ![Validate EU VAT ID](docs/vat_check.png)
 
-### HR
+- Allow deletion of the most recent sales transaction only
+
+    This ensures consecutive numbering of transactions. Applies to **Quotation**, **Sales Order**, **Sales Invoice**.
 
 - Custom fields in **Employee** (tax information, etc.)
 - List of religios denominations ("Konfessionen")

--- a/erpnext_germany/custom/sales.py
+++ b/erpnext_germany/custom/sales.py
@@ -1,0 +1,26 @@
+import frappe
+from frappe import _
+from erpnext.controllers.selling_controller import SellingController
+
+
+def on_trash(doc: SellingController, event: str = None) -> None:
+	if doc.flags.ignore_validate:
+		return
+
+	if is_not_latest(doc.doctype, doc.name, doc.creation):
+		frappe.throw(
+			msg=_(
+				"Only the most recent {0} can be deleted in order to avoid gaps in numbering."
+			).format(_(doc.doctype)),
+			title=_("Cannot delete this transaction"),
+		)
+
+
+def is_not_latest(doctype, name, creation):
+	return frappe.db.exists(
+		doctype,
+		{
+			"creation": (">", creation),
+			"name": ("!=", name),
+		},
+	)

--- a/erpnext_germany/hooks.py
+++ b/erpnext_germany/hooks.py
@@ -106,13 +106,17 @@ before_uninstall = "erpnext_germany.uninstall.before_uninstall"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-# 	}
-# }
+doc_events = {
+	"Quotation": {
+		"on_trash": "erpnext_germany.custom.sales.on_trash",
+	},
+	"Sales Order": {
+		"on_trash": "erpnext_germany.custom.sales.on_trash",
+	},
+	"Sales Invoice": {
+		"on_trash": "erpnext_germany.custom.sales.on_trash",
+	},
+}
 
 # doc_events = {}
 

--- a/erpnext_germany/translations/de.csv
+++ b/erpnext_germany/translations/de.csv
@@ -41,3 +41,5 @@ Completed,Abgeschlossen
 Service Unavailable,Dienst nicht verfügbar
 Invalid Input,Ungültige Eingabe
 Error,Fehler
+Cannot delete this transaction,Diese Transaktion kann nicht gelöscht werden
+Only the most recent {0} can be deleted in order to avoid gaps in numbering.,"Nur die neueste Transaktion vom Typ {0} kann gelöscht werden, um Lücken in der Nummerierung zu vermeiden."


### PR DESCRIPTION
Allow deletion of the most recent sales transaction only. This ensures consecutive numbering of transactions. Applies to **Quotation**, **Sales Order**, **Sales Invoice**.