### PR TITLE
fix(Employee): remove property setters for "bank_ac_no" and "ctc"

### DIFF
--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -11,3 +11,4 @@ erpnext_germany.patches.import_business_trip_regions
 execute:from erpnext_germany.install import make_custom_fields; make_custom_fields()
 execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming", 1)
 erpnext_germany.patches.set_business_trip_settings
+erpnext_germany.patches.remove_some_employee_property_setters

--- a/erpnext_germany/patches/remove_some_employee_property_setters.py
+++ b/erpnext_germany/patches/remove_some_employee_property_setters.py
@@ -1,0 +1,23 @@
+import frappe
+
+
+def execute():
+	frappe.db.delete(
+		"Property Setter",
+		{
+			"doc_type": "Employee",
+			"field_name": "bank_ac_no",
+			"property": "label",
+			"value": "IBAN",
+		},
+	)
+
+	frappe.db.delete(
+		"Property Setter",
+		{
+			"doc_type": "Employee",
+			"field_name": "ctc",
+			"property": "hidden",
+			"value": 1,
+		},
+	)

--- a/erpnext_germany/property_setters.py
+++ b/erpnext_germany/property_setters.py
@@ -2,8 +2,6 @@ def get_property_setters():
 	return {
 		"Employee": [
 			("salary_currency", "default", "EUR"),
-			("bank_ac_no", "label", "IBAN"),
-			("ctc", "hidden", 1),
 			("salary_mode", "default", "Bank"),
 			("permanent_accommodation_type", "hidden", 1),
 			("current_accommodation_type", "hidden", 1),


### PR DESCRIPTION
- The field "Bank Account No" got "IBAN" as a custom label. Meanwhile, we have a separate _IBAN_ field. To avoid having two _IBAN_ fields, we change the label back to "Bank Account No".
- The field _Cost To Company_ was hidden, I don't remember why. Unhide this.