### PR TITLE
feat: add workflow to build ERPNext Docker image with ALYF custom apps

### DIFF
--- a/.github/helpers/apps.json
+++ b/.github/helpers/apps.json
@@ -1,0 +1,30 @@
+[
+  {
+    "url": "https://github.com/frappe/erpnext",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/frappe/hrms.git",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/alyf-de/erpnext_pdf-on-submit.git",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/alyf-de/erpnext_germany.git",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/alyf-de/erpnext_datev.git",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/alyf-de/banking.git",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/alyf-de/eu_einvoice.git",
+    "branch": "version-15"
+  }
+]

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,66 @@
+name: Build Container Image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    branches:
+      - version-15
+    tags:
+      - "*"
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout Entire Repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/${{ matrix.arch }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Set Branch
+        run: |
+          export APPS_JSON_PATH='${{ github.workspace }}/.github/helper/apps.json'
+          echo "APPS_JSON_BASE64=$(cat $APPS_JSON_PATH | base64 -w 0)" >> $GITHUB_ENV
+          echo "FRAPPE_BRANCH=version-15" >> $GITHUB_ENV
+
+      - name: Set Image Tag
+        run: |
+          echo "IMAGE_TAG=stable" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe_docker
+          path: builds
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: builds
+          file: builds/images/layered/Containerfile
+          tags: >
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }},
+            ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+          build-args: |
+            "FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH }}"
+            "APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }}"

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -11,10 +11,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-
     permissions:
       packages: write
 
@@ -27,8 +23,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/${{ matrix.arch }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -54,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           context: builds
           file: builds/images/layered/Containerfile
           tags: >

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
 jobs:
   build:
     name: Build

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -32,7 +32,7 @@ jobs:
           
       - name: Set Branch
         run: |
-          export APPS_JSON_PATH='${{ github.workspace }}/.github/helper/apps.json'
+          export APPS_JSON_PATH='${{ github.workspace }}/.github/helpers/apps.json'
           echo "APPS_JSON_BASE64=$(cat $APPS_JSON_PATH | base64 -w 0)" >> $GITHUB_ENV
           echo "FRAPPE_BRANCH=version-15" >> $GITHUB_ENV
 

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -3,9 +3,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  push:
-    branches:
-      - main
 jobs:
   build:
     name: Build

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -53,7 +53,6 @@ jobs:
           context: builds
           file: builds/images/layered/Containerfile
           tags: >
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }},
             ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
           build-args: |
             "FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH }}"

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/helpers/apps.json'
+      - '.github/workflows/build_image.yml'
 jobs:
   build:
     name: Build

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - version-15
-    tags:
-      - "*"
+      - '**'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This PR introduces a GitHub workflow to automatically build a Docker image containing ERPNext along with ALYF custom apps. 

**What’s Included**

`apps.json`: 

- A configuration file that defines all apps and their branches to be included in the Docker Image.

`build_image.yml`: 
- Builds a Docker image using frappe_docker as the base
- Uses a multi-platform build for amd64 and arm64
- Pushes the final image to a container registry 

**Notes:**

The resulting image is currently named after the repository (erpnext_germany).
The workflow is currently triggered on:

- 	Pushes to the main branch
- 	Manual triggers via the GitHub Actions UI

But not if any of the custom apps change.
