### PR TITLE
fix: strip whitespace and add more detailed error messages

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: Pytest
+
+on:
+  pull_request: {}
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest erpnext_germany/utils/test_utils.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 erpnext_germany/docs/current
 erpnext_germany/public/dist
 build/
+.pytest_cache/

--- a/erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.py
+++ b/erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from tenacity import RetryError
 
@@ -11,10 +12,18 @@ from erpnext_germany.utils.eu_vat import check_vat_approx, parse_vat_id
 class VATIDCheck(Document):
 	def before_insert(self):
 		if self.requester_vat_id:
-			requester_country_code, requester_vat_number = parse_vat_id(self.requester_vat_id)
+			try:
+				requester_country_code, requester_vat_number = parse_vat_id(self.requester_vat_id)
+			except ValueError:
+				frappe.throw(
+					_("The VAT ID in {0} is invalid.").format(_(self.meta.get_label("requester_vat_id")))
+				)
 			self.requester_vat_id = f"{requester_country_code}{requester_vat_number}"
 
-		country_code, vat_number = parse_vat_id(self.party_vat_id)
+		try:
+			country_code, vat_number = parse_vat_id(self.party_vat_id)
+		except ValueError:
+			frappe.throw(_("The VAT ID in {0} is invalid.").format(_(self.meta.get_label("party_vat_id"))))
 		self.party_vat_id = f"{country_code}{vat_number}"
 
 	def after_insert(self):

--- a/erpnext_germany/utils/eu_vat.py
+++ b/erpnext_germany/utils/eu_vat.py
@@ -17,8 +17,10 @@ VAT_NUMBER_REGEX = r"^[0-9A-Za-z\+\*\.]{2,12}$"
 
 
 def parse_vat_id(vat_id: str) -> tuple[str, str]:
-	country_code = vat_id.strip()[:2].upper()
-	vat_number = vat_id.strip()[2:].replace(" ", "")
+	_vat_id = vat_id.replace(" ", "")
+
+	country_code = _vat_id[:2].upper()
+	vat_number = _vat_id[2:]
 
 	# check vat_number and country_code with regex
 	if not re.match(COUNTRY_CODE_REGEX, country_code):

--- a/erpnext_germany/utils/eu_vat.py
+++ b/erpnext_germany/utils/eu_vat.py
@@ -17,15 +17,15 @@ VAT_NUMBER_REGEX = r"^[0-9A-Za-z\+\*\.]{2,12}$"
 
 
 def parse_vat_id(vat_id: str) -> tuple[str, str]:
-	country_code = vat_id[:2].upper()
-	vat_number = vat_id[2:].replace(" ", "")
+	country_code = vat_id.strip()[:2].upper()
+	vat_number = vat_id.strip()[2:].replace(" ", "")
 
 	# check vat_number and country_code with regex
 	if not re.match(COUNTRY_CODE_REGEX, country_code):
-		raise ValueError("Invalid country code")
+		raise ValueError(f"Invalid country code: {country_code}")
 
 	if not re.match(VAT_NUMBER_REGEX, vat_number):
-		raise ValueError("Invalid VAT number")
+		raise ValueError(f"Invalid VAT number: {vat_number}")
 
 	return country_code, vat_number
 

--- a/erpnext_germany/utils/test_utils.py
+++ b/erpnext_germany/utils/test_utils.py
@@ -1,22 +1,82 @@
-from unittest import TestCase
+import pytest
 
-from .eu_vat import is_valid_vat_id
+from .eu_vat import parse_vat_id
 
 
-class TestUtils(TestCase):
-	def test_validate_vat_id(self):
-		valid_ids = [
-			"DE329035522",  # ALYF
-			"DE210157578",  # SAP
-		]
-		invalid_ids = [
-			"ABC123",
-			"Test Test",
-			"DE1234567890",
-		]
+def test_parse_vat_id_valid():
+	"""Test parsing valid VAT IDs."""
+	# Test with no spaces
+	country_code, vat_number = parse_vat_id("DE329035522")
+	assert country_code == "DE"
+	assert vat_number == "329035522"
 
-		for vat_id in valid_ids:
-			self.assertTrue(is_valid_vat_id(vat_id))
+	# Test with spaces in VAT number (should be removed)
+	country_code, vat_number = parse_vat_id("DE329 035 522")
+	assert country_code == "DE"
+	assert vat_number == "329035522"
 
-		for vat_id in invalid_ids:
-			self.assertFalse(is_valid_vat_id(vat_id))
+	# Test with lowercase country code (should be uppercased)
+	country_code, vat_number = parse_vat_id("de210157578")
+	assert country_code == "DE"
+	assert vat_number == "210157578"
+
+	# Test with mixed case
+	country_code, vat_number = parse_vat_id("Fr12345678901")
+	assert country_code == "FR"
+	assert vat_number == "12345678901"
+
+
+def test_parse_vat_id_invalid_country_code():
+	"""Test parsing VAT IDs with invalid country codes."""
+	# Too short country code (only 1 character provided)
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D123456789")
+
+	# Non-alphabetic country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D1123456789")
+
+	# Numbers in country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("12123456789")
+
+	# Special characters in country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D-123456789")
+
+
+def test_parse_vat_id_invalid_vat_number():
+	"""Test parsing VAT IDs with invalid VAT numbers."""
+	# Too short VAT number (less than 2 characters)
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE1")
+
+	# Too long VAT number (more than 12 characters)
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE1234567890123")
+
+	# Invalid characters in VAT number
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE123-456789")
+
+	# Special characters not allowed
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE123@456789")
+
+
+def test_parse_vat_id_edge_cases():
+	"""Test edge cases for VAT ID parsing."""
+	# Minimum length VAT number (2 characters)
+	country_code, vat_number = parse_vat_id("DE12")
+	assert country_code == "DE"
+	assert vat_number == "12"
+
+	# Maximum length VAT number (12 characters)
+	country_code, vat_number = parse_vat_id("DE123456789012")
+	assert country_code == "DE"
+	assert vat_number == "123456789012"
+
+	# VAT number with allowed special characters
+	country_code, vat_number = parse_vat_id("DE123+456*78.9")
+	assert country_code == "DE"
+	assert vat_number == "123+456*78.9"


### PR DESCRIPTION
Remove all whitespace from the VAT ID and improve error messages to show exactly which part is invalid.

e.g. an invalid number:

`parse_vat_id("1DE3456")`

`ValueError: Invalid country code: 1D
`

Closes: #79 