### PR TITLE
test: parse_vat_id

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: Pytest
+
+on:
+  pull_request: {}
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest erpnext_germany/utils/test_utils.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 erpnext_germany/docs/current
 erpnext_germany/public/dist
 build/
+.pytest_cache/

--- a/erpnext_germany/utils/test_utils.py
+++ b/erpnext_germany/utils/test_utils.py
@@ -1,22 +1,82 @@
-from unittest import TestCase
+import pytest
 
-from .eu_vat import is_valid_vat_id
+from .eu_vat import parse_vat_id
 
 
-class TestUtils(TestCase):
-	def test_validate_vat_id(self):
-		valid_ids = [
-			"DE329035522",  # ALYF
-			"DE210157578",  # SAP
-		]
-		invalid_ids = [
-			"ABC123",
-			"Test Test",
-			"DE1234567890",
-		]
+def test_parse_vat_id_valid():
+	"""Test parsing valid VAT IDs."""
+	# Test with no spaces
+	country_code, vat_number = parse_vat_id("DE329035522")
+	assert country_code == "DE"
+	assert vat_number == "329035522"
 
-		for vat_id in valid_ids:
-			self.assertTrue(is_valid_vat_id(vat_id))
+	# Test with spaces in VAT number (should be removed)
+	country_code, vat_number = parse_vat_id("DE329 035 522")
+	assert country_code == "DE"
+	assert vat_number == "329035522"
 
-		for vat_id in invalid_ids:
-			self.assertFalse(is_valid_vat_id(vat_id))
+	# Test with lowercase country code (should be uppercased)
+	country_code, vat_number = parse_vat_id("de210157578")
+	assert country_code == "DE"
+	assert vat_number == "210157578"
+
+	# Test with mixed case
+	country_code, vat_number = parse_vat_id("Fr12345678901")
+	assert country_code == "FR"
+	assert vat_number == "12345678901"
+
+
+def test_parse_vat_id_invalid_country_code():
+	"""Test parsing VAT IDs with invalid country codes."""
+	# Too short country code (only 1 character provided)
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D123456789")
+	
+	# Non-alphabetic country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D1123456789")
+	
+	# Numbers in country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("12123456789")
+	
+	# Special characters in country code
+	with pytest.raises(ValueError, match="Invalid country code"):
+		parse_vat_id("D-123456789")
+
+
+def test_parse_vat_id_invalid_vat_number():
+	"""Test parsing VAT IDs with invalid VAT numbers."""
+	# Too short VAT number (less than 2 characters)
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE1")
+
+	# Too long VAT number (more than 12 characters)
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE1234567890123")
+
+	# Invalid characters in VAT number
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE123-456789")
+
+	# Special characters not allowed
+	with pytest.raises(ValueError, match="Invalid VAT number"):
+		parse_vat_id("DE123@456789")
+
+
+def test_parse_vat_id_edge_cases():
+	"""Test edge cases for VAT ID parsing."""
+	# Minimum length VAT number (2 characters)
+	country_code, vat_number = parse_vat_id("DE12")
+	assert country_code == "DE"
+	assert vat_number == "12"
+
+	# Maximum length VAT number (12 characters)
+	country_code, vat_number = parse_vat_id("DE123456789012")
+	assert country_code == "DE"
+	assert vat_number == "123456789012"
+
+	# VAT number with allowed special characters
+	country_code, vat_number = parse_vat_id("DE123+456*78.9")
+	assert country_code == "DE"
+	assert vat_number == "123+456*78.9"

--- a/erpnext_germany/utils/test_utils.py
+++ b/erpnext_germany/utils/test_utils.py
@@ -31,15 +31,15 @@ def test_parse_vat_id_invalid_country_code():
 	# Too short country code (only 1 character provided)
 	with pytest.raises(ValueError, match="Invalid country code"):
 		parse_vat_id("D123456789")
-	
+
 	# Non-alphabetic country code
 	with pytest.raises(ValueError, match="Invalid country code"):
 		parse_vat_id("D1123456789")
-	
+
 	# Numbers in country code
 	with pytest.raises(ValueError, match="Invalid country code"):
 		parse_vat_id("12123456789")
-	
+
 	# Special characters in country code
 	with pytest.raises(ValueError, match="Invalid country code"):
 		parse_vat_id("D-123456789")


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for running `pytest` and refactors the VAT ID utility tests to use `pytest` instead of `unittest`. It also expands the test coverage for VAT ID parsing to include various edge cases and invalid inputs.

### CI/CD Enhancements:
* Added a new GitHub Actions workflow (`.github/workflows/pytest.yml`) to automate running `pytest` on pull requests. It sets up Python 3.10, installs dependencies, and runs tests in `erpnext_germany/utils/test_utils.py`.

### Test Refactoring and Improvements:
* Refactored `erpnext_germany/utils/test_utils.py` to use `pytest` instead of `unittest`, simplifying the test structure and improving readability.
* Replaced `is_valid_vat_id` tests with new tests for `parse_vat_id`, covering valid VAT ID parsing, invalid country codes, invalid VAT numbers, and edge cases. Examples include handling mixed case inputs, invalid characters, and maximum/minimum length constraints.