### PR TITLE
feat(Business Trip): consider Employee's paid advances for Expense Claims (DRC-198)

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -25,6 +25,7 @@
   "section_break_12",
   "journeys",
   "total_mileage_allowance",
+  "employee_paid_journey_expenses",
   "section_break_14",
   "accommodations",
   "section_break_16",
@@ -191,8 +192,16 @@
    "fieldtype": "Currency",
    "label": "Total Mileage Allowance",
    "read_only": 1
+  },
+  {
+   "description": "Expenses paid by the Employee (excl. mileage allowance)",
+   "fieldname": "employee_paid_journey_expenses",
+   "fieldtype": "Currency",
+   "label": "Employee Paid Journey Expenses",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [
@@ -201,7 +210,7 @@
    "link_fieldname": "business_trip"
   }
  ],
- "modified": "2025-02-20 10:58:45.064314",
+ "modified": "2025-09-09 16:37:47.047959",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip",
@@ -260,6 +269,7 @@
    "role": "Accounts User"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -33,6 +33,8 @@
   "region",
   "allowances",
   "total_allowance",
+  "section_break_18",
+  "total_claim",
   "amended_from"
  ],
  "fields": [
@@ -172,6 +174,16 @@
    "read_only": 1
   },
   {
+   "fieldname": "section_break_18",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "total_claim",
+   "fieldtype": "Currency",
+   "label": "Total Claim",
+   "read_only": 1
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -217,7 +229,7 @@
    "link_fieldname": "business_trip"
   }
  ],
- "modified": "2025-09-09 16:57:47.047959",
+ "modified": "2025-09-09 17:07:47.047959",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -28,6 +28,7 @@
   "employee_paid_journey_expenses",
   "section_break_14",
   "accommodations",
+  "employee_paid_accommodation_expenses",
   "section_break_16",
   "region",
   "allowances",
@@ -194,10 +195,16 @@
    "read_only": 1
   },
   {
-   "description": "Expenses paid by the Employee (excl. mileage allowance)",
+   "description": "Journey Expenses paid by the employee (excl. mileage allowance)",
    "fieldname": "employee_paid_journey_expenses",
    "fieldtype": "Currency",
    "label": "Employee Paid Journey Expenses",
+   "read_only": 1
+  },
+  {
+   "fieldname": "employee_paid_accommodation_expenses",
+   "fieldtype": "Currency",
+   "label": "Employee Paid Accommodation Expenses",
    "read_only": 1
   }
  ],
@@ -210,7 +217,7 @@
    "link_fieldname": "business_trip"
   }
  ],
- "modified": "2025-09-09 16:37:47.047959",
+ "modified": "2025-09-09 16:57:47.047959",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -56,6 +56,7 @@ class BusinessTrip(Document):
 		total_allowance: DF.Currency
 		total_mileage_allowance: DF.Currency
 		employee_paid_accommodation_expenses: DF.Currency
+		total_claim: DF.Currency
 	# end: auto-generated types
 
 	def before_save(self):
@@ -66,6 +67,7 @@ class BusinessTrip(Document):
 		self.calculate_total_mileage_allowance()
 		self.calculate_journeys_expenses()
 		self.calculate_accommodation_expenses()
+		self.calculate_total_claim()
 
 	def validate(self):
 		self.validate_from_to_dates("from_date", "to_date")
@@ -121,6 +123,14 @@ class BusinessTrip(Document):
 	def calculate_accommodation_expenses(self):
 		self.employee_paid_accommodation_expenses = sum(
 			accommodation.expenses for accommodation in self.accommodations
+		)
+
+	def calculate_total_claim(self):
+		self.total_claim = (
+			(self.total_allowance or 0)
+			+ (self.total_mileage_allowance or 0)
+			+ (self.employee_paid_journey_expenses or 0)
+			+ (self.employee_paid_accommodation_expenses or 0)
 		)
 
 	def before_submit(self):

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -150,10 +150,14 @@ class BusinessTrip(Document):
 			mileage_allowance=settings.mileage_allowance or 0.0,
 		)
 		expenses.extend(
-			get_journey_expenses(self, settings.expense_claim_type_for_other_journey_expenses or DEFAULT_EXPENSE_CLAIM_TYPE)
+			get_journey_expenses(
+				self, settings.expense_claim_type_for_other_journey_expenses or DEFAULT_EXPENSE_CLAIM_TYPE
+			)
 		)
 		expenses.extend(
-			get_accommodation_expenses(self, settings.expense_claim_type_for_accommodations or DEFAULT_EXPENSE_CLAIM_TYPE)
+			get_accommodation_expenses(
+				self, settings.expense_claim_type_for_accommodations or DEFAULT_EXPENSE_CLAIM_TYPE
+			)
 		)
 		expenses.extend(get_meal_expenses(self, settings.expense_claim_type or DEFAULT_EXPENSE_CLAIM_TYPE))
 
@@ -245,8 +249,7 @@ def get_accommodation_expenses(business_trip: BusinessTrip, expense_claim_type: 
 			continue
 
 		description = (
-			f"Unterkunft in {accommodation.city} "
-			f"({accommodation.from_date} - {accommodation.to_date})"
+			f"Unterkunft in {accommodation.city} ({accommodation.from_date} - {accommodation.to_date})"
 		)
 
 		expenses.append(

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -58,11 +58,12 @@ class BusinessTrip(Document):
 	# end: auto-generated types
 
 	def before_save(self):
-		self.reset_distance()
+		self.reset_distance_and_journeys_expenses()
 		self.set_regional_amount()
 		self.set_whole_day_time()
 		self.calculate_total()
 		self.calculate_total_mileage_allowance()
+		self.calculate_journeys_expenses()
 
 	def validate(self):
 		self.validate_from_to_dates("from_date", "to_date")
@@ -92,9 +93,11 @@ class BusinessTrip(Document):
 
 			allowance.amount = max(amount, 0.0)
 
-	def reset_distance(self):
+	def reset_distance_and_journeys_expenses(self):
 		for journey in self.journeys:
-			if journey.mode_of_transport != "Car (private)":
+			if journey.mode_of_transport == "Car (private)":
+				journey.expenses = 0
+			else:
 				journey.distance = 0
 
 	def set_whole_day_time(self):
@@ -109,6 +112,9 @@ class BusinessTrip(Document):
 	def calculate_total_mileage_allowance(self):
 		mileage_allowance = frappe.db.get_single_value("Business Trip Settings", "mileage_allowance") or 0
 		self.total_mileage_allowance = sum(journey.distance for journey in self.journeys) * mileage_allowance
+
+	def calculate_journeys_expenses(self):
+		self.employee_paid_journey_expenses = sum(journey.expenses for journey in self.journeys)
 
 	def before_submit(self):
 		self.status = "Submitted"

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -55,6 +55,7 @@ class BusinessTrip(Document):
 		to_date: DF.Date
 		total_allowance: DF.Currency
 		total_mileage_allowance: DF.Currency
+		employee_paid_accommodation_expenses: DF.Currency
 	# end: auto-generated types
 
 	def before_save(self):
@@ -64,6 +65,7 @@ class BusinessTrip(Document):
 		self.calculate_total()
 		self.calculate_total_mileage_allowance()
 		self.calculate_journeys_expenses()
+		self.calculate_accommodation_expenses()
 
 	def validate(self):
 		self.validate_from_to_dates("from_date", "to_date")
@@ -115,6 +117,11 @@ class BusinessTrip(Document):
 
 	def calculate_journeys_expenses(self):
 		self.employee_paid_journey_expenses = sum(journey.expenses for journey in self.journeys)
+
+	def calculate_accommodation_expenses(self):
+		self.employee_paid_accommodation_expenses = sum(
+			accommodation.expenses for accommodation in self.accommodations
+		)
 
 	def before_submit(self):
 		self.status = "Submitted"

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -149,6 +149,12 @@ class BusinessTrip(Document):
 			expense_claim_type=settings.expense_claim_type_car or DEFAULT_EXPENSE_CLAIM_TYPE,
 			mileage_allowance=settings.mileage_allowance or 0.0,
 		)
+		expenses.extend(
+			get_journey_expenses(self, settings.expense_claim_type_for_other_journey_expenses or DEFAULT_EXPENSE_CLAIM_TYPE)
+		)
+		expenses.extend(
+			get_accommodation_expenses(self, settings.expense_claim_type_for_accommodations or DEFAULT_EXPENSE_CLAIM_TYPE)
+		)
 		expenses.extend(get_meal_expenses(self, settings.expense_claim_type or DEFAULT_EXPENSE_CLAIM_TYPE))
 
 		if not expenses:
@@ -195,6 +201,61 @@ def get_mileage_allowances(
 				"description": description,
 				"amount": mileage_amount,
 				"sanctioned_amount": mileage_amount,
+				"project": business_trip.project,
+				"cost_center": business_trip.cost_center,
+			},
+		)
+
+	return expenses
+
+
+def get_journey_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> list[dict]:
+	"""Return a list of expense claim rows for journey expenses (excl. mileage allowance)."""
+	expenses = []
+	for journey in business_trip.journeys:
+		if not journey.expenses:
+			continue
+
+		description = "Fahrt von {from_place} nach {to_place} ({mode})".format(
+			from_place=getattr(journey, "from"),
+			to_place=journey.to,
+			mode=journey.mode_of_transport,
+		)
+
+		expenses.append(
+			{
+				"expense_date": journey.date,
+				"expense_type": expense_claim_type,
+				"description": description,
+				"amount": journey.expenses,
+				"sanctioned_amount": journey.expenses,
+				"project": business_trip.project,
+				"cost_center": business_trip.cost_center,
+			},
+		)
+
+	return expenses
+
+
+def get_accommodation_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> list[dict]:
+	"""Return a list of expense claim rows for accommodation expenses."""
+	expenses = []
+	for accommodation in business_trip.accommodations:
+		if not accommodation.expenses:
+			continue
+
+		description = (
+			f"Unterkunft in {accommodation.city} "
+			f"({accommodation.from_date} - {accommodation.to_date})"
+		)
+
+		expenses.append(
+			{
+				"expense_date": accommodation.from_date,
+				"expense_type": expense_claim_type,
+				"description": description,
+				"amount": accommodation.expenses,
+				"sanctioned_amount": accommodation.expenses,
 				"project": business_trip.project,
 				"cost_center": business_trip.cost_center,
 			},

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
@@ -9,6 +9,7 @@
   "from_date",
   "to_date",
   "city",
+  "expenses",
   "receipt"
  ],
  "fields": [
@@ -34,6 +35,13 @@
    "reqd": 1
   },
   {
+   "description": "Expenses paid by the Employee for accommodation.",
+   "fieldname": "expenses",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Expenses"
+  },
+  {
    "fieldname": "receipt",
    "fieldtype": "Attach",
    "in_list_view": 1,
@@ -43,7 +51,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-04 22:59:37.891096",
+ "modified": "2024-09-09 16:57:37.891096",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Accommodation",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.py
@@ -15,6 +15,7 @@ class BusinessTripAccommodation(Document):
 		from frappe.types import DF
 
 		city: DF.Data
+		expenses: DF.Currency
 		from_date: DF.Date
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
@@ -10,6 +10,7 @@
   "from",
   "to",
   "distance",
+  "expenses",
   "receipt"
  ],
  "fields": [
@@ -55,17 +56,26 @@
    "fieldtype": "Int",
    "label": "Distance",
    "non_negative": 1
+  },
+  {
+   "depends_on": "eval:doc.mode_of_transport!==\"Car (private)\"",
+   "description": "Expenses paid by the Employee.",
+   "fieldname": "expenses",
+   "fieldtype": "Currency",
+   "label": "Expenses"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-20 11:01:39.706560",
+ "modified": "2025-09-09 16:21:28.209089",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Journey",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
@@ -5,8 +5,10 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "expense_claim_type",
   "expense_claim_type_car",
+  "expense_claim_type_for_other_journey_expenses",
+  "expense_claim_type_for_accommodations",
+  "expense_claim_type",
   "mileage_allowance"
  ],
  "fields": [
@@ -33,12 +35,27 @@
    "label": "Expense Claim Type for Mileage Allowance",
    "options": "Expense Claim Type",
    "reqd": 1
+  },
+  {
+   "fieldname": "expense_claim_type_for_other_journey_expenses",
+   "fieldtype": "Link",
+   "label": "Expense Claim Type for Other Journey Expenses",
+   "options": "Expense Claim Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "expense_claim_type_for_accommodations",
+   "fieldtype": "Link",
+   "label": "Expense Claim Type for Accommodations",
+   "options": "Expense Claim Type",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-26 12:23:22.874639",
+ "modified": "2025-09-09 17:57:34.876836",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Settings",
@@ -55,6 +72,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.py
@@ -16,6 +16,8 @@ class BusinessTripSettings(Document):
 
 		expense_claim_type: DF.Link
 		expense_claim_type_car: DF.Link
+		expense_claim_type_for_accommodations: DF.Link
+		expense_claim_type_for_other_journey_expenses: DF.Link
 		mileage_allowance: DF.Currency
 	# end: auto-generated types
 	pass


### PR DESCRIPTION
# Overview
This PR enhances the **Business Trip**, such that both **Business Trip Journeys** and **Business Trip Accommodation** can records claims by the employee. 

Use case: Employee paid journeys (taxi etc.) or accommodations from "his own pocket".

The two new "expense types" are also considered when the **Expense Claim** is created.

# Screenshots
<img width="1064" height="487" alt="image" src="https://github.com/user-attachments/assets/0c95e9cb-1d97-4177-813a-114b37461068" />


Similiarly there is a new field for accomodations and a total field that sums all (now 4) fields with claims:
<img width="1064" height="813" alt="image" src="https://github.com/user-attachments/assets/1bf36483-0cdc-4de7-910a-441e1c3e7e1e" />


internal ref: DRC-198