### PR TITLE
feat(Purchase Invoice): enable employee payments independent of Business Trip

### DIFF
--- a/erpnext_germany/custom/purchase_invoice.py
+++ b/erpnext_germany/custom/purchase_invoice.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2025, ALYF GmbH and Contributors
-# See license.txt
-
-
-def before_validate(doc, event):
-	if not doc.business_trip:
-		doc.business_trip_employee = None
-		doc.pay_to_employee = 0

--- a/erpnext_germany/custom_fields.py
+++ b/erpnext_germany/custom_fields.py
@@ -176,7 +176,7 @@ def get_custom_fields():
 				"label": _("Business Trip Employee"),
 				"options": "Employee",
 				"insert_after": "business_trip",
-				"read_only": 0,
+				"read_only": 0,  # kept 0 on purpose to override former value
 				"read_only_depends_on": "business_trip",
 				"mandatory_depends_on": "pay_to_employee",
 				"fetch_from": "business_trip.employee",
@@ -189,7 +189,7 @@ def get_custom_fields():
 				"fieldname": "pay_to_employee",
 				"label": _("Pay to Employee"),
 				"insert_after": "business_trip_employee",
-				"depends_on": "",
+				"depends_on": "",  # kept empty on purpose to override former value
 				"description": _(
 					"If checked, the invoice was advanced by the employee and must be reimbursed."
 				),

--- a/erpnext_germany/custom_fields.py
+++ b/erpnext_germany/custom_fields.py
@@ -176,9 +176,12 @@ def get_custom_fields():
 				"label": _("Business Trip Employee"),
 				"options": "Employee",
 				"insert_after": "business_trip",
-				"read_only": 1,
+				"read_only": 0,
+				"read_only_depends_on": "business_trip",
+				"mandatory_depends_on": "pay_to_employee",
 				"fetch_from": "business_trip.employee",
-				"depends_on": "eval: doc.business_trip",
+				"fetch_if_empty": 1,
+				"depends_on": "eval: doc.business_trip || doc.pay_to_employee",
 				"ignore_user_permissions": 1,
 			},
 			{
@@ -186,7 +189,7 @@ def get_custom_fields():
 				"fieldname": "pay_to_employee",
 				"label": _("Pay to Employee"),
 				"insert_after": "business_trip_employee",
-				"depends_on": "business_trip",
+				"depends_on": "",
 				"description": _(
 					"If checked, the invoice was advanced by the employee and must be reimbursed."
 				),

--- a/erpnext_germany/hooks.py
+++ b/erpnext_germany/hooks.py
@@ -116,9 +116,6 @@ doc_events = {
 	"Sales Invoice": {
 		"on_trash": "erpnext_germany.custom.sales.on_trash",
 	},
-	"Purchase Invoice": {
-		"before_validate": "erpnext_germany.custom.purchase_invoice.before_validate",
-	},
 }
 
 # doc_events = {}

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -8,7 +8,7 @@ erpnext_germany.patches.change_position_of_register_info
 erpnext_germany.patches.dynamic_party_in_vat_id_check
 erpnext_germany.patches.add_business_trip_to_expense_claim
 erpnext_germany.patches.import_business_trip_regions
-execute:from erpnext_germany.install import make_custom_fields; make_custom_fields() # 2025-09-19 #2
+execute:from erpnext_germany.install import make_custom_fields; make_custom_fields() # 2025-10-01
 execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming", 1)
 erpnext_germany.patches.set_business_trip_settings
 erpnext_germany.patches.remove_some_employee_property_setters


### PR DESCRIPTION
## Business Process
Employee payments can also exist without a **Business Trip**.
Example: Employee goes to supermarket and buys coffee for the office.

## Solution
Use the existing fields and make them compatible with the above use case. This mainly involves changes in field settings (depends_on, read_only, fetch_if_empty, ...)

## Depends on
https://github.com/alyf-de/banking/pull/282 
Dependency is not very strong. The features in Banking won't break, but they also can't use Payments to Employee independent of Business Trip. 
This might cause misunderstanding in practice!