### PR TITLE
feat(Business Trip): add data structure for other expenses

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js
@@ -101,6 +101,12 @@ frappe.ui.form.on("Business Trip Allowance", {
 	},
 });
 
+frappe.ui.form.on("Business Trip Other Expense", {
+	create_purchase_invoice(frm, cdt, cdn) {
+		create_purchase_invoice_with_receipt(frm, cdt, cdn);
+	},
+});
+
 function show_processing_details_dialog(frm) {
 	frappe.call({
 		method: "erpnext_germany.erpnext_germany.doctype.business_trip.business_trip.get_processing_details",
@@ -226,10 +232,12 @@ function get_dates(row) {
 	const FROM_DATE_MAP = {
 		"Business Trip Accommodation": "from_date",
 		"Business Trip Journey": "date",
+		"Business Trip Other Expense": "date",
 	};
 	const TO_DATE_MAP = {
 		"Business Trip Accommodation": "to_date",
 		"Business Trip Journey": "date",
+		"Business Trip Other Expense": "date",
 	};
 
 	return {

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -31,6 +31,8 @@
   "region",
   "allowances",
   "total_allowance",
+  "section_break_vadz",
+  "other_expenses",
   "amended_from"
  ],
  "fields": [
@@ -191,6 +193,17 @@
    "fieldtype": "Currency",
    "label": "Total Mileage Allowance",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_vadz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "other_expenses",
+   "fieldtype": "Table",
+   "label": "Other Expenses",
+   "options": "Business Trip Other Expense",
+   "description": "Everything that is not covered by the journeys, accommodations or allowances (e.g. parking fees, conference tickets, etc.)"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -205,7 +218,7 @@
    "link_fieldname": "business_trip"
   }
  ],
- "modified": "2025-09-19 17:11:36.711485",
+ "modified": "2025-10-17 15:45:41.213645",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -27,7 +27,7 @@ class BusinessTrip(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import (
+		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import (  # noqa: E501
 			BusinessTripAccommodation,
 		)
 		from erpnext_germany.erpnext_germany.doctype.business_trip_allowance.business_trip_allowance import (
@@ -36,7 +36,7 @@ class BusinessTrip(Document):
 		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import (
 			BusinessTripJourney,
 		)
-		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expense.business_trip_other_expense import (
+		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expense.business_trip_other_expense import (  # noqa: E501
 			BusinessTripOtherExpense,
 		)
 

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -25,11 +25,20 @@ class BusinessTrip(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import BusinessTripAccommodation
-		from erpnext_germany.erpnext_germany.doctype.business_trip_allowance.business_trip_allowance import BusinessTripAllowance
-		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import BusinessTripJourney
-		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expenses.business_trip_other_expenses import BusinessTripOtherExpenses
 		from frappe.types import DF
+
+		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import (
+			BusinessTripAccommodation,
+		)
+		from erpnext_germany.erpnext_germany.doctype.business_trip_allowance.business_trip_allowance import (
+			BusinessTripAllowance,
+		)
+		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import (
+			BusinessTripJourney,
+		)
+		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expenses.business_trip_other_expenses import (
+			BusinessTripOtherExpenses,
+		)
 
 		accommodations: DF.Table[BusinessTripAccommodation]
 		allowances: DF.Table[BusinessTripAllowance]

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -36,8 +36,8 @@ class BusinessTrip(Document):
 		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import (
 			BusinessTripJourney,
 		)
-		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expenses.business_trip_other_expenses import (
-			BusinessTripOtherExpenses,
+		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expense.business_trip_other_expense import (
+			BusinessTripOtherExpense,
 		)
 
 		accommodations: DF.Table[BusinessTripAccommodation]
@@ -51,7 +51,7 @@ class BusinessTrip(Document):
 		employee_name: DF.Data | None
 		from_date: DF.Date
 		journeys: DF.Table[BusinessTripJourney]
-		other_expenses: DF.Table[BusinessTripOtherExpenses]
+		other_expenses: DF.Table[BusinessTripOtherExpense]
 		project: DF.Link | None
 		region: DF.Link
 		status: DF.Literal["", "Submitted", "Approved", "Rejected", "Paid", "Billed"]

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -25,17 +25,11 @@ class BusinessTrip(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import BusinessTripAccommodation
+		from erpnext_germany.erpnext_germany.doctype.business_trip_allowance.business_trip_allowance import BusinessTripAllowance
+		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import BusinessTripJourney
+		from erpnext_germany.erpnext_germany.doctype.business_trip_other_expenses.business_trip_other_expenses import BusinessTripOtherExpenses
 		from frappe.types import DF
-
-		from erpnext_germany.erpnext_germany.doctype.business_trip_accommodation.business_trip_accommodation import (  # noqa: E501
-			BusinessTripAccommodation,
-		)
-		from erpnext_germany.erpnext_germany.doctype.business_trip_allowance.business_trip_allowance import (
-			BusinessTripAllowance,
-		)
-		from erpnext_germany.erpnext_germany.doctype.business_trip_journey.business_trip_journey import (
-			BusinessTripJourney,
-		)
 
 		accommodations: DF.Table[BusinessTripAccommodation]
 		allowances: DF.Table[BusinessTripAllowance]
@@ -48,6 +42,7 @@ class BusinessTrip(Document):
 		employee_name: DF.Data | None
 		from_date: DF.Date
 		journeys: DF.Table[BusinessTripJourney]
+		other_expenses: DF.Table[BusinessTripOtherExpenses]
 		project: DF.Link | None
 		region: DF.Link
 		status: DF.Literal["", "Submitted", "Approved", "Rejected", "Paid", "Billed"]

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
@@ -7,32 +7,21 @@
  "engine": "InnoDB",
  "field_order": [
   "date",
-  "expense_type",
   "description",
   "receipt",
   "create_purchase_invoice"
  ],
  "fields": [
   {
-   "columns": 3,
-   "fieldname": "expense_type",
-   "fieldtype": "Link",
+   "columns": 5,
+   "fieldname": "description",
+   "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Expense Type",
-   "options": "Expense Claim Type",
+   "label": "Description",
    "reqd": 1
   },
   {
    "columns": 3,
-   "fetch_from": "expense_type.expense_type",
-   "fetch_if_empty": 1,
-   "fieldname": "description",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Description"
-  },
-  {
-   "columns": 2,
    "fieldname": "receipt",
    "fieldtype": "Attach",
    "in_list_view": 1,
@@ -40,7 +29,7 @@
   },
   {
    "columns": 2,
-    "fieldname": "date",
+   "fieldname": "date",
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Date",
@@ -57,7 +46,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-17 15:51:42.522747",
+ "modified": "2025-10-17 20:10:46.166227",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Other Expense",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
@@ -1,0 +1,70 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-17 15:30:30.296111",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "expense_type",
+  "description",
+  "receipt",
+  "create_purchase_invoice"
+ ],
+ "fields": [
+  {
+   "columns": 3,
+   "fieldname": "expense_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Expense Type",
+   "options": "Expense Claim Type",
+   "reqd": 1
+  },
+  {
+   "columns": 3,
+   "fetch_from": "expense_type.expense_type",
+   "fetch_if_empty": 1,
+   "fieldname": "description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Description"
+  },
+  {
+   "columns": 2,
+   "fieldname": "receipt",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Receipt"
+  },
+  {
+   "columns": 2,
+    "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval: doc.receipt && frappe.model.can_create(\"Purchase Invoice\")",
+   "fieldname": "create_purchase_invoice",
+   "fieldtype": "Button",
+   "label": "Create Purchase Invoice"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-17 15:51:42.522747",
+ "modified_by": "Administrator",
+ "module": "ERPNext Germany",
+ "name": "Business Trip Other Expense",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.py
@@ -15,8 +15,7 @@ class BusinessTripOtherExpense(Document):
 		from frappe.types import DF
 
 		date: DF.Date
-		description: DF.Data | None
-		expense_type: DF.Link
+		description: DF.Data
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BusinessTripOtherExpense(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		date: DF.Date
+		description: DF.Data | None
+		expense_type: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		receipt: DF.Attach | None
+	# end: auto-generated types
+	pass

--- a/erpnext_germany/locale/de.po
+++ b/erpnext_germany/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-09-26 14:59+0053\n"
+"POT-Creation-Date: 2025-10-17 15:54+0053\n"
 "PO-Revision-Date: 2025-02-20 11:46+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -59,10 +59,6 @@ msgstr "Tatsächlicher Name des Händlers"
 msgid "Address"
 msgstr "Adresse"
 
-#: erpnext_germany/custom_fields.py:187
-msgid "Advance Paid by Employee"
-msgstr "Vorschuss vom Mitarbeiter bezahlt"
-
 #. Option for the 'Mode of Transport' (Select) field in DocType 'Business Trip
 #. Journey'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
@@ -110,6 +106,10 @@ msgstr "Ankunft oder Abreise"
 msgid "August"
 msgstr "August"
 
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
+msgid "Before creating a purchase invoice, please save this record."
+msgstr "Bitte speichern Sie diesen Datensatz, bevor Sie eine Eingangsrechnung erstellen."
+
 #. Option for the 'Status' (Select) field in DocType 'Business Trip'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 msgid "Billed"
@@ -143,7 +143,7 @@ msgstr "Geschäftsbriefvorlage"
 #. Name of a DocType
 #. Linked DocType in Business Trip Region's connections
 #. Label of a shortcut in the Germany Workspace
-#: erpnext_germany/custom_fields.py:169 erpnext_germany/custom_fields.py:221
+#: erpnext_germany/custom_fields.py:169 erpnext_germany/custom_fields.py:225
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
@@ -169,6 +169,11 @@ msgstr "Dienstreise-Mitarbeiter"
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
 msgid "Business Trip Journey"
 msgstr "Dienstreise-Fahrt"
+
+#. Name of a DocType
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Business Trip Other Expense"
+msgstr "Dienstreise-Sonstige Ausgaben"
 
 #. Name of a DocType
 #. Label of a Link in the Germany Workspace
@@ -215,7 +220,7 @@ msgstr "Anzahl Kinderfreibeträge"
 msgid "City"
 msgstr "Stadt"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:165
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:194
 msgid "Close"
 msgstr ""
 
@@ -258,8 +263,10 @@ msgstr "Kostenstelle"
 
 #. Label of a Button field in DocType 'Business Trip Accommodation'
 #. Label of a Button field in DocType 'Business Trip Journey'
+#. Label of a Button field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Create Purchase Invoice"
 msgstr "Eingangsrechnung erstellen"
 
@@ -293,9 +300,11 @@ msgstr "Kunde"
 #. Label of a Date field in DocType 'Business Letter'
 #. Label of a Date field in DocType 'Business Trip Allowance'
 #. Label of a Date field in DocType 'Business Trip Journey'
+#. Label of a Date field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Date"
 msgstr "Datum"
 
@@ -324,6 +333,11 @@ msgstr "Dezember"
 msgid "Department"
 msgstr "Abteilung"
 
+#. Label of a Data field in DocType 'Business Trip Other Expense'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Description"
+msgstr ""
+
 #. Label of a Check field in DocType 'Business Trip Allowance'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
 msgid "Dinner was Provided"
@@ -339,11 +353,11 @@ msgstr "Deaktiviert"
 msgid "Distance"
 msgstr "Entfernung"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:134
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:141
 msgid "DocType"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:142
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:149
 msgid "Document Name"
 msgstr ""
 
@@ -384,6 +398,11 @@ msgstr "Name des Mitarbeiters"
 msgid "Error"
 msgstr "Fehler"
 
+#. Description of the 'Other Expenses' (Table) field in DocType 'Business Trip'
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+msgid "Everything that is not covered by the journeys, accommodations or allowances (e.g. parking fees, conference tickets, etc.)"
+msgstr "Alles, was nicht durch Fahrten, Unterkünfte oder Verpflegungspauschalen abgedeckt ist (z.B. Parkgebühren, Konferenztickets, etc.)"
+
 #. Linked DocType in Business Trip's connections
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 msgid "Expense Claim"
@@ -398,6 +417,11 @@ msgstr "Art der Auslagenabrechnung für Verpflegungsmehraufwände"
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 msgid "Expense Claim Type for Mileage Allowance"
 msgstr "Art der Auslagenabrechnung für Kilometerpauschale"
+
+#. Label of a Link field in DocType 'Business Trip Other Expense'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Expense Type"
+msgstr "Ausgabenart"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30
 msgid "February"
@@ -441,7 +465,7 @@ msgstr "Ab Uhrzeit"
 msgid "Germany"
 msgstr "Deutschland"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:150
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:164
 msgid "Grand Total"
 msgstr ""
 
@@ -467,11 +491,9 @@ msgstr "Hat Nebenbeschäftigungen"
 msgid "Highest School Qualification"
 msgstr "Höchster Schulabschluss"
 
-# Description of a Check field in DocType 'Purchase Invoice'
-# erpnext_germany/custom_fields.py
-#: erpnext_germany/custom_fields.py:191
-msgid "If checked, the invoice was advanced by the employee."
-msgstr "Wenn aktiviert, wurde die Rechnung vom Mitarbeiter vorgestreckt."
+#: erpnext_germany/custom_fields.py:193
+msgid "If checked, the invoice was advanced by the employee and must be reimbursed."
+msgstr "Wenn aktiviert, wurde die Rechnung vom Mitarbeiter vorgestreckt und muss erstattet werden."
 
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:8
 msgid "Invalid"
@@ -523,7 +545,7 @@ msgstr "Verknüpftes Dokument"
 msgid "Link Title"
 msgstr "Titel des verknüpften Dokuments"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:122
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:123
 msgid "Linked Documents"
 msgstr ""
 
@@ -569,12 +591,8 @@ msgstr "Monat"
 msgid "Nationality"
 msgstr "Nationalität"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:196
-msgid "No linked documents found"
-msgstr ""
-
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:173
-msgid "No processing details found."
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:182
+msgid "No linked documents found."
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:39
@@ -588,6 +606,11 @@ msgstr "Oktober"
 #: erpnext_germany/custom/sales.py:15
 msgid "Only the most recent {0} can be deleted in order to avoid gaps in numbering."
 msgstr "Nur die neueste Transaktion vom Typ {0} kann gelöscht werden, um Lücken in der Nummerierung zu vermeiden."
+
+#. Label of a Table field in DocType 'Business Trip'
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+msgid "Other Expenses"
+msgstr "Sonstige Ausgaben"
 
 #. Option for the 'Status' (Select) field in DocType 'Business Trip'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -620,6 +643,10 @@ msgstr "Parteityp"
 msgid "Party VAT ID"
 msgstr "USt-IdNr. der Partei"
 
+#: erpnext_germany/custom_fields.py:190
+msgid "Pay to Employee"
+msgstr "An Mitarbeiter zahlen"
+
 #. Option for the 'Status' (Select) field in DocType 'VAT ID Check'
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:10
@@ -629,10 +656,6 @@ msgstr "Geplant"
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:65
 msgid "Please enter a start and end date of the trip!"
 msgstr "Bitte geben Sie das Start- und Enddatum Ihrer Reise ein!"
-
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
-msgid "Please save the Business Trip document first before creating a Purchase Invoice."
-msgstr "Bitte speichern Sie die Dienstreise, bevor Sie eine Eingangsrechnung erstellen."
 
 #. Label of a Check field in DocType 'ERPNext Germany Settings'
 #: erpnext_germany/erpnext_germany/doctype/erpnext_germany_settings/erpnext_germany_settings.json
@@ -644,7 +667,7 @@ msgstr ""
 msgid "Preview"
 msgstr "Vorschau"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:117
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:191
 msgid "Processing Details"
 msgstr "Bearbeitungsdetails"
 
@@ -671,8 +694,10 @@ msgstr ""
 
 #. Label of a Attach field in DocType 'Business Trip Accommodation'
 #. Label of a Attach field in DocType 'Business Trip Journey'
+#. Label of a Attach field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Receipt"
 msgstr "Beleg"
 
@@ -795,7 +820,7 @@ msgstr "Bearbeitungsdetails anzeigen"
 
 #. Label of a Select field in DocType 'Business Trip'
 #. Label of a Select field in DocType 'VAT ID Check'
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:171
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 msgid "Status"
@@ -825,6 +850,10 @@ msgstr "Gebucht"
 msgid "Summen- und Saldenliste"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+msgid "Supplier Name"
+msgstr ""
+
 #. Name of a role
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
 #: erpnext_germany/erpnext_germany/doctype/business_letter_template/business_letter_template.json
@@ -841,7 +870,7 @@ msgstr ""
 msgid "Tax Bracket"
 msgstr "Steuerklasse"
 
-#: erpnext_germany/custom_fields.py:196 erpnext_germany/custom_fields.py:207
+#: erpnext_germany/custom_fields.py:200 erpnext_germany/custom_fields.py:211
 msgid "Tax Exemption Reason"
 msgstr "Steuerbefreiungsgrund"
 

--- a/erpnext_germany/locale/de.po
+++ b/erpnext_germany/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-20 00:38+0053\n"
+"POT-Creation-Date: 2025-10-20 00:48+0053\n"
 "PO-Revision-Date: 2025-02-20 11:46+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -417,11 +417,6 @@ msgstr "Art der Auslagenabrechnung für Verpflegungsmehraufwände"
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 msgid "Expense Claim Type for Mileage Allowance"
 msgstr "Art der Auslagenabrechnung für Kilometerpauschale"
-
-#. Label of a Link field in DocType 'Business Trip Other Expense'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
-msgid "Expense Type"
-msgstr "Ausgabenart"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30
 msgid "February"

--- a/erpnext_germany/locale/main.pot
+++ b/erpnext_germany/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-09-26 14:59+0053\n"
-"PO-Revision-Date: 2025-09-26 14:59+0053\n"
+"POT-Creation-Date: 2025-10-17 15:54+0053\n"
+"PO-Revision-Date: 2025-10-17 15:54+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -55,10 +55,6 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Business Letter'
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
 msgid "Address"
-msgstr ""
-
-#: erpnext_germany/custom_fields.py:187
-msgid "Advance Paid by Employee"
 msgstr ""
 
 #. Option for the 'Mode of Transport' (Select) field in DocType 'Business Trip
@@ -108,6 +104,10 @@ msgstr ""
 msgid "August"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
+msgid "Before creating a purchase invoice, please save this record."
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Business Trip'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 msgid "Billed"
@@ -141,7 +141,7 @@ msgstr ""
 #. Name of a DocType
 #. Linked DocType in Business Trip Region's connections
 #. Label of a shortcut in the Germany Workspace
-#: erpnext_germany/custom_fields.py:169 erpnext_germany/custom_fields.py:221
+#: erpnext_germany/custom_fields.py:169 erpnext_germany/custom_fields.py:225
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
@@ -166,6 +166,11 @@ msgstr ""
 #. Name of a DocType
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
 msgid "Business Trip Journey"
+msgstr ""
+
+#. Name of a DocType
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Business Trip Other Expense"
 msgstr ""
 
 #. Name of a DocType
@@ -213,7 +218,7 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:165
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:194
 msgid "Close"
 msgstr ""
 
@@ -256,8 +261,10 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Business Trip Accommodation'
 #. Label of a Button field in DocType 'Business Trip Journey'
+#. Label of a Button field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Create Purchase Invoice"
 msgstr ""
 
@@ -291,9 +298,11 @@ msgstr ""
 #. Label of a Date field in DocType 'Business Letter'
 #. Label of a Date field in DocType 'Business Trip Allowance'
 #. Label of a Date field in DocType 'Business Trip Journey'
+#. Label of a Date field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Date"
 msgstr ""
 
@@ -322,6 +331,11 @@ msgstr ""
 msgid "Department"
 msgstr ""
 
+#. Label of a Data field in DocType 'Business Trip Other Expense'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Description"
+msgstr ""
+
 #. Label of a Check field in DocType 'Business Trip Allowance'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
 msgid "Dinner was Provided"
@@ -337,11 +351,11 @@ msgstr ""
 msgid "Distance"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:134
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:141
 msgid "DocType"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:142
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:149
 msgid "Document Name"
 msgstr ""
 
@@ -382,6 +396,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#. Description of the 'Other Expenses' (Table) field in DocType 'Business Trip'
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+msgid "Everything that is not covered by the journeys, accommodations or allowances (e.g. parking fees, conference tickets, etc.)"
+msgstr ""
+
 #. Linked DocType in Business Trip's connections
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 msgid "Expense Claim"
@@ -395,6 +414,11 @@ msgstr ""
 #. Label of a Link field in DocType 'Business Trip Settings'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 msgid "Expense Claim Type for Mileage Allowance"
+msgstr ""
+
+#. Label of a Link field in DocType 'Business Trip Other Expense'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
+msgid "Expense Type"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30
@@ -439,7 +463,7 @@ msgstr ""
 msgid "Germany"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:150
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:164
 msgid "Grand Total"
 msgstr ""
 
@@ -465,8 +489,8 @@ msgstr ""
 msgid "Highest School Qualification"
 msgstr ""
 
-#: erpnext_germany/custom_fields.py:191
-msgid "If checked, the invoice was advanced by the employee."
+#: erpnext_germany/custom_fields.py:193
+msgid "If checked, the invoice was advanced by the employee and must be reimbursed."
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:8
@@ -519,7 +543,7 @@ msgstr ""
 msgid "Link Title"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:122
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:123
 msgid "Linked Documents"
 msgstr ""
 
@@ -565,12 +589,8 @@ msgstr ""
 msgid "Nationality"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:196
-msgid "No linked documents found"
-msgstr ""
-
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:173
-msgid "No processing details found."
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:182
+msgid "No linked documents found."
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:39
@@ -583,6 +603,11 @@ msgstr ""
 
 #: erpnext_germany/custom/sales.py:15
 msgid "Only the most recent {0} can be deleted in order to avoid gaps in numbering."
+msgstr ""
+
+#. Label of a Table field in DocType 'Business Trip'
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+msgid "Other Expenses"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Business Trip'
@@ -616,6 +641,10 @@ msgstr ""
 msgid "Party VAT ID"
 msgstr ""
 
+#: erpnext_germany/custom_fields.py:190
+msgid "Pay to Employee"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'VAT ID Check'
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:10
@@ -624,10 +653,6 @@ msgstr ""
 
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:65
 msgid "Please enter a start and end date of the trip!"
-msgstr ""
-
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
-msgid "Please save the Business Trip document first before creating a Purchase Invoice."
 msgstr ""
 
 #. Label of a Check field in DocType 'ERPNext Germany Settings'
@@ -640,7 +665,7 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:117
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:191
 msgid "Processing Details"
 msgstr ""
 
@@ -667,8 +692,10 @@ msgstr ""
 
 #. Label of a Attach field in DocType 'Business Trip Accommodation'
 #. Label of a Attach field in DocType 'Business Trip Journey'
+#. Label of a Attach field in DocType 'Business Trip Other Expense'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_accommodation/business_trip_accommodation.json
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
 msgid "Receipt"
 msgstr ""
 
@@ -791,7 +818,7 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Business Trip'
 #. Label of a Select field in DocType 'VAT ID Check'
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:171
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 msgid "Status"
@@ -821,6 +848,10 @@ msgstr ""
 msgid "Summen- und Saldenliste"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+msgid "Supplier Name"
+msgstr ""
+
 #. Name of a role
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
 #: erpnext_germany/erpnext_germany/doctype/business_letter_template/business_letter_template.json
@@ -837,7 +868,7 @@ msgstr ""
 msgid "Tax Bracket"
 msgstr ""
 
-#: erpnext_germany/custom_fields.py:196 erpnext_germany/custom_fields.py:207
+#: erpnext_germany/custom_fields.py:200 erpnext_germany/custom_fields.py:211
 msgid "Tax Exemption Reason"
 msgstr ""
 

--- a/erpnext_germany/locale/main.pot
+++ b/erpnext_germany/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-20 00:38+0053\n"
-"PO-Revision-Date: 2025-10-20 00:38+0053\n"
+"POT-Creation-Date: 2025-10-20 00:48+0053\n"
+"PO-Revision-Date: 2025-10-20 00:48+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -414,11 +414,6 @@ msgstr ""
 #. Label of a Link field in DocType 'Business Trip Settings'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 msgid "Expense Claim Type for Mileage Allowance"
-msgstr ""
-
-#. Label of a Link field in DocType 'Business Trip Other Expense'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_other_expense/business_trip_other_expense.json
-msgid "Expense Type"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30


### PR DESCRIPTION
# Problem
Some expenses, such as parking tickets or entrance fees, don't fit anywhere in the current data structure.

# Solution
New Child DocType: **Business Trip Other Expense**
<img width="1266" height="387" alt="image" src="https://github.com/user-attachments/assets/24cceb2e-4bbd-45a1-a419-5e41eed87701" />


----
Internal Ref: DRC-224