### PR TITLE
fix: auto-fetch parent fields into Business Trip Region Allowances 

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.js
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.js
@@ -1,8 +1,36 @@
 // Copyright (c) 2024, ALYF GmbH and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Business Trip Region", {
-// 	refresh(frm) {
 
-// 	},
-// });
+frappe.ui.form.on('Business Trip Region', {
+    whole_day(frm) {
+        frm.events.copy_parent_values(frm);
+    },
+    arrival_or_departure(frm) {
+        frm.events.copy_parent_values(frm);
+    },
+    accommodation(frm) {
+        frm.events.copy_parent_values(frm);
+    },
+
+    copy_parent_values(frm) {
+        if (!frm.doc.allowances?.length) return;
+
+        frm.doc.allowances.forEach(row => {
+            frappe.model.set_value(row.doctype, row.name, 'full_day', frm.doc.whole_day);
+            frappe.model.set_value(row.doctype, row.name, 'arrival__departure', frm.doc.arrival_or_departure);
+            frappe.model.set_value(row.doctype, row.name, 'accommodation', frm.doc.accommodation);
+        });
+
+        frm.refresh_field("allowances");
+    }
+});
+
+frappe.ui.form.on('Business Trip Region Allowance', {
+    valid_till(frm, cdt, cdn) {
+        frappe.model.set_value(cdt, cdn, 'full_day', frm.doc.whole_day);
+        frappe.model.set_value(cdt, cdn, 'arrival__departure', frm.doc.arrival_or_departure);
+        frappe.model.set_value(cdt, cdn, 'accommodation', frm.doc.accommodation);
+        frm.refresh_field("allowances");
+    }
+});

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -1,24 +1,67 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils import getdate
+from frappe import _
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from frappe.types import DF
 
 
 class BusinessTripRegion(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+        accommodation: "DF.Currency"
+        arrival_or_departure: "DF.Currency"
+        disabled: "DF.Check"
+        title: "DF.Data | None"
+        valid_from: "DF.Date | None"
+        whole_day: "DF.Currency"
+   
+    def validate(self):
+     """
+        1) Warn if no allowances.
+        2) Validate unique valid_till.
+     """
+        self._ensure_title()
+        self._warn_if_no_allowances()
+        self._validate_allowance_valid_till_unique()
 
-		accommodation: DF.Currency
-		arrival_or_departure: DF.Currency
-		disabled: DF.Check
-		title: DF.Data | None
-		valid_from: DF.Date | None
-		whole_day: DF.Currency
-	# end: auto-generated types
-	pass
+    def _warn_if_no_allowances(self):
+        """Show warning if there are no allowance rows."""
+        if not getattr(self, "allowances", []):
+            frappe.msgprint(
+                _("No allowance entries found under this region. "
+                  "Please add at least one record in the <b>Allowances</b> table.")
+            )
+
+    def _validate_allowance_valid_till_unique(self):
+        """Ensure that each allowance row has a valid_till and no duplicates exist."""
+        rows = getattr(self, "allowances", []) or []
+        seen_dates = set()
+
+        for idx, row in enumerate(rows, start=1):
+            vt_raw = getattr(row, "valid_till", None) or row.get("valid_till")
+            if not vt_raw:
+                frappe.throw(_("Allowance row {0}: Please set a Valid Till date.").format(idx))
+
+            try:
+                vt_date = getdate(vt_raw)
+            except Exception:
+                frappe.throw(
+                    _("Allowance row {0}: Invalid date format for Valid Till: {1}")
+                    .format(idx, vt_raw)
+                )
+
+            if vt_date in seen_dates:
+                frappe.throw(
+                    _("Duplicate Valid Till date found in row {0}: {1}. "
+                      "Each row must have a unique Valid Till date.")
+                    .format(idx, vt_date)
+                )
+
+            seen_dates.add(vt_date)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -27,7 +27,7 @@ class BusinessTripRegion(Document):
         1) Warn if no allowances.
         2) Validate unique valid_till.
      """
-        self._ensure_title()
+       
         self._warn_if_no_allowances()
         self._validate_allowance_valid_till_unique()
 

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
@@ -1,0 +1,55 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-25 11:12:10.378046",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "valid_till",
+  "full_day",
+  "arrival__departure",
+  "accommodation"
+ ],
+ "fields": [
+  {
+   "fieldname": "valid_till",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Valid Till"
+  },
+  {
+   "fieldname": "full_day",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Full Day"
+  },
+  {
+   "fieldname": "arrival__departure",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Arrival / Departure"
+  },
+  {
+   "fieldname": "accommodation",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Accommodation"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-25 11:15:54.730476",
+ "modified_by": "Administrator",
+ "module": "ERPNext Germany",
+ "name": "Business Trip Region Allowance",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+# from frappe.model.document import Document
+
+
+# class BusinessTripRegionAllowance(Document):
+# 	  pass


### PR DESCRIPTION
 Summary

This PR improves the `Business Trip Region` behaviour by ensuring allowance values are correctly fetched from parent fields both on the client side (before save) and server side (before validation).

Changes Introduced
- client-side (JS):
  - Automatically copies parent fields (`whole_day`, `arrival_or_departure`, `accommodation`) to all rows in the `allowances` child table.
  - Updates instantly when the user edits any of these parent fields or selects a `valid_till` date in child rows.

-Server-side (Python):
  - Added `before_validate` method to populate allowances from parent before saving/submitting.
  - Ensures backend consistency even if the document is saved via API or JS is disabled.

Testing
1. Open **Business Trip Region**.
2. Add at least one allowance row.
3. Fill in `Whole Day`, `Arrival or Departure`, and `Accommodation`.
4. Observe:
   - Child table fields auto-update immediately.
   - On saving, backend logic ensures values persist correctly.

Reference
Requested as per feedback on previous migration PR to keep data consistent and user-friendly.

c
