### PR TITLE
feat: adjust Business Trip logic to use new data structure

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -1,24 +1,41 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe import _  
+from typing import TYPE_CHECKING 
 
 class BusinessTripRegion(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+   
+    if TYPE_CHECKING:
+       
+        from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import BusinessTripRegionAllowance
+        from frappe.types import DF
 
-	from typing import TYPE_CHECKING
+        accommodation: DF.Currency
+        allowances: DF.Table[BusinessTripRegionAllowance] 
+        arrival_or_departure: DF.Currency
+        disabled: DF.Check
+        title: DF.Data | None
+        valid_from: DF.Date | None
+        whole_day: DF.Currency
+    
+    def validate(self):
+        """
+        Validate that no child row's 'valid_till' date
+        is the same as the parent's 'valid_from' date.
+        """
+        if not self.valid_from:
+            return 
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		accommodation: DF.Currency
-		arrival_or_departure: DF.Currency
-		disabled: DF.Check
-		title: DF.Data | None
-		valid_from: DF.Date | None
-		whole_day: DF.Currency
-	# end: auto-generated types
-	pass
+        for row in self.allowances:
+            if row.valid_till and row.valid_till == self.valid_from:
+                
+                frappe.throw(
+                    _("Row #{0}: The 'Valid Till' date ({1}) cannot be the same as the parent's 'Valid From' date.").format(
+                        row.idx, 
+                        row.valid_till
+                    ),
+                    title="Invalid Date"
+                )

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
@@ -1,0 +1,55 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-27 22:46:54.274590",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "valid_till",
+  "full_day",
+  "arrival__departure",
+  "accommodation"
+ ],
+ "fields": [
+  {
+   "fieldname": "valid_till",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Valid Till"
+  },
+  {
+   "fieldname": "full_day",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Full Day"
+  },
+  {
+   "fieldname": "arrival__departure",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Arrival / Departure"
+  },
+  {
+   "fieldname": "accommodation",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Accommodation"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-27 22:50:32.111079",
+ "modified_by": "Administrator",
+ "module": "ERPNext Germany",
+ "name": "Business Trip Region Allowance",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class BusinessTripRegionAllowance(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		accommodation: DF.Currency
+		arrival__departure: DF.Currency
+		full_day: DF.Currency
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		valid_till: DF.Date | None
+	# end: auto-generated types
+	pass

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -13,3 +13,4 @@ execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_
 erpnext_germany.patches.set_business_trip_settings
 erpnext_germany.patches.remove_some_employee_property_setters
 execute:from erpnext_germany.install import make_property_setters; make_property_setters()
+erpnext_germany.patches.fix_allowance_data_and_date

--- a/erpnext_germany/patches/fix_allowance_data_and_date.py
+++ b/erpnext_germany/patches/fix_allowance_data_and_date.py
@@ -1,0 +1,82 @@
+import frappe
+from frappe import _
+
+PARENT_DOCTYPE = "Business Trip Region"
+CHILD_TABLE_FIELD = "allowances"
+
+def execute():
+    
+    updated_docs = 0
+    created_rows_total = 0  # Changed this counter
+    errors = 0
+
+    try:
+        regions = frappe.get_all(
+            PARENT_DOCTYPE,
+            fields=["name", "whole_day", "arrival_or_departure", "accommodation"],
+        )
+    except Exception as e:
+        frappe.log_error(f"Patch failed: Could not get {PARENT_DOCTYPE} list. {e}")
+        return
+
+    if not regions:
+        print("No Business Trip Region records found; nothing to do.")
+        return
+
+    total_docs = len(regions)
+    print(f"Found {total_docs} '{PARENT_DOCTYPE}' documents to process...")
+
+    for i, r in enumerate(regions):
+        name = r.get("name")
+        
+        try:
+            doc = frappe.get_doc(PARENT_DOCTYPE, name)
+            
+            # Get parent values
+            parent_whole_day = r.get("whole_day") or 0
+            parent_arrival = r.get("arrival_or_departure") or 0
+            parent_accom = r.get("accommodation") or 0
+
+            # 1. DELETE all previous rows
+            doc.set(CHILD_TABLE_FIELD, [])
+
+            # 2. CREATE one new row
+            new_row = doc.append(CHILD_TABLE_FIELD, {})
+            
+            # 3. SET values on the new row
+            new_row.full_day = parent_whole_day
+            new_row.arrival__departure = parent_arrival
+            new_row.accommodation = parent_accom
+            # 'valid_till' will be None by default
+
+            # 4. SAVE the document
+            doc.save(ignore_permissions=True)
+            
+            updated_docs += 1
+            created_rows_total += 1  # We added 1 new row
+            print(f"Processing doc ({i + 1}/{total_docs}): {name} -> REPLACED all rows with 1 new row.")
+
+        except Exception:
+            errors += 1
+            frappe.log_error(frappe.get_traceback(), title=f"Patch Error: {name}")
+            print(f"Processing doc ({i + 1}/{total_docs}): {name} -> ERROR (see error.log)")
+            continue
+
+    
+    frappe.db.commit()
+
+    summary = {
+        "updated_docs": updated_docs,
+        "created_rows": created_rows_total,
+        "errors": errors,
+    }
+    
+    # Updated summary message to reflect the new action
+    summary_message = _(
+        "Business Trip Allowances Data REPLACED: Created {created_rows} new rows in {updated_docs} documents, "
+        "errors {errors}"
+    ).format(**summary)
+    
+    print(f"--- Patch Complete ---")
+    print(summary_message)
+    frappe.msgprint(summary_message)


### PR DESCRIPTION

Title: fix: Migrate Business Trip Region allowance data to child table

### **Description:**

This PR migrates the allowance fields (`whole_day`, `arrival_or_departure`, `accommodation`) from the parent `Business Trip Region` document into the new `allowances` child table.

This is necessary to support multiple allowance rates with different `valid_till` dates for a single region, which was the goal of the new data structure.

Changes in this PR:

1.  New Patch 
    * Iterates over all `Business Trip Region` documents.
    * For documents that have **no child rows**, it creates one new row in the `allowances` table.
    * It copies the parent's `whole_day`, `arrival_or_departure`, and `accommodation` values into the new row.
    * The `valid_till` field in the new row is left empty (`None`) for users to set manually.

2.  Validation (`business_trip_region.py`):
    * Adds a server-side `validate` method to the `BusinessTripRegion` DocType.
    * This prevents a user from saving the document if any child row's `valid_till` date is the same as the parent's `valid_from` date, ensuring data integrity.

