### PR TITLE
fix: preventing naming gaps now validates each series individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ App to hold regional code for Germany, built on top of ERPNext.
 
     ![Validate EU VAT ID](docs/vat_check.png)
 
-- Allow deletion of the most recent sales transaction only
+- Allow deletion of the most recent sales transaction (per naming series and company) only
 
     This ensures consecutive numbering of transactions. Applies to **Quotation**, **Sales Order**, **Sales Invoice**.
 

--- a/erpnext_germany/custom/sales.py
+++ b/erpnext_germany/custom/sales.py
@@ -10,21 +10,36 @@ def on_trash(doc: SellingController, event: str | None = None) -> None:
 	if not frappe.db.get_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming"):
 		return
 
-	if is_not_latest(doc.doctype, doc.name, doc.creation, doc.company):
+	if is_not_latest_in_series(doc.doctype, doc.name, doc.creation, doc.company, doc.naming_series):
 		frappe.throw(
-			msg=_("Only the most recent {0} can be deleted in order to avoid gaps in numbering.").format(
-				_(doc.doctype)
-			),
+			msg=_(
+				"Only the most recent {0} within the same series can be deleted in order to avoid gaps in numbering."
+			).format(_(doc.doctype)),
 			title=_("Cannot delete this transaction"),
 		)
 
 
-def is_not_latest(doctype, name, creation, company):
+def is_not_latest_in_series(doctype, name, creation, company, naming_series):
+	# Check if the document is not the latest within its naming series and company.
+
+	if not naming_series:
+		# If no naming series, fallback to old global behavior
+		return frappe.db.exists(
+			doctype,
+			{
+				"creation": (">", creation),
+				"name": ("!=", name),
+				"company": company,
+			},
+		)
+
+	# Filter for newer docs in the same naming_series
 	return frappe.db.exists(
 		doctype,
 		{
 			"creation": (">", creation),
 			"name": ("!=", name),
 			"company": company,
+			"naming_series": naming_series,
 		},
 	)

--- a/erpnext_germany/custom/sales.py
+++ b/erpnext_germany/custom/sales.py
@@ -10,7 +10,9 @@ def on_trash(doc: SellingController, event: str | None = None) -> None:
 	if not frappe.db.get_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming"):
 		return
 
-	if is_not_latest_in_series(doc.doctype, doc.name, doc.creation, doc.company, doc.naming_series):
+	if is_not_latest_in_series(
+		doc.doctype, doc.name, doc.creation, doc.company, getattr(doc, "naming_series", None)
+	):
 		frappe.throw(
 			msg=_(
 				"Only the most recent {0} within the same series can be deleted to avoid gaps in numbering."
@@ -19,7 +21,7 @@ def on_trash(doc: SellingController, event: str | None = None) -> None:
 		)
 
 
-def is_not_latest_in_series(doctype, name, creation, company, naming_series):
+def is_not_latest_in_series(doctype, name, creation, company, naming_series: str | None = None):
 	# Check if the document is not the latest within its naming series and company.
 
 	if not naming_series:

--- a/erpnext_germany/custom/sales.py
+++ b/erpnext_germany/custom/sales.py
@@ -13,7 +13,7 @@ def on_trash(doc: SellingController, event: str | None = None) -> None:
 	if is_not_latest_in_series(doc.doctype, doc.name, doc.creation, doc.company, doc.naming_series):
 		frappe.throw(
 			msg=_(
-				"Only the most recent {0} within the same series can be deleted in order to avoid gaps in numbering."
+				"Only the most recent {0} within the same series can be deleted to avoid gaps in numbering."
 			).format(_(doc.doctype)),
 			title=_("Cannot delete this transaction"),
 		)

--- a/erpnext_germany/custom/sales.py
+++ b/erpnext_germany/custom/sales.py
@@ -22,10 +22,9 @@ def on_trash(doc: SellingController, event: str | None = None) -> None:
 
 
 def is_not_latest_in_series(doctype, name, creation, company, naming_series: str | None = None):
-	# Check if the document is not the latest within its naming series and company.
-
+	"""Check if the document is not the latest within its naming series and company."""
 	if not naming_series:
-		# If no naming series, fallback to old global behavior
+		# find a newer doc with the same company
 		return frappe.db.exists(
 			doctype,
 			{
@@ -35,7 +34,7 @@ def is_not_latest_in_series(doctype, name, creation, company, naming_series: str
 			},
 		)
 
-	# Filter for newer docs in the same naming_series
+	# find a newer doc with the same naming series and company
 	return frappe.db.exists(
 		doctype,
 		{


### PR DESCRIPTION
…when using more than one naming series such as "RE-" and "GU-" for sales invoice.

When using more than one naming series (for example, "RE-" and "GU-") for Sales Invoices, the “prevent gaps in transaction naming” validation previously blocked deletion of newer documents even if they belonged to different naming series.

With this update, the validation now checks for gaps within each naming series independently — allowing you to delete the newest document of a given series, even if there are newer documents with another prefix.

Example:

RE-0005

GU-0007

Previously, if RE-0005 was newer, you couldn’t delete GU-0007.

Now, each series (RE- and GU-) is validated separately, so you can safely delete the newest document of either series.