### PR TITLE
feat(Business Trip Region): adjust the data structure to retrieve date specific allowance rates

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -80,7 +80,7 @@ class BusinessTrip(Document):
 			)
 			whole_day = days_rates.whole_day
 			arrival_or_departure = days_rates.arrival_or_departure
-			accomodation = days_rates.accommodation
+			accommodation = days_rates.accommodation
 
 			amount = whole_day if allowance.whole_day else arrival_or_departure
 			if allowance.breakfast_was_provided:
@@ -93,7 +93,7 @@ class BusinessTrip(Document):
 				amount -= whole_day * 0.4
 
 			if not allowance.accommodation_was_provided:
-				amount += accomodation
+				amount += accommodation
 
 			allowance.amount = max(amount, 0.0)
 
@@ -195,10 +195,10 @@ def get_meal_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> l
 		description = "Ganztägig" if allowance.whole_day else "An-/Abreise"
 
 		allowance_rates = _get_allowance_rates(business_trip.region, allowance.date)
-		accomodation = next(
+		accommodation = next(
 			rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
 		).accommodation
-		if not allowance.accommodation_was_provided and accomodation:
+		if not allowance.accommodation_was_provided and accommodation:
 			description += ", zzgl. Hotel"
 
 		if allowance.breakfast_was_provided:

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -74,22 +74,13 @@ class BusinessTrip(Document):
 		if not self.region:
 			return
 
-		allowance_rates = _get_allowance_rates(self.region, self.to_date)
-
 		for allowance in self.allowances:
 			whole_day = 0.0
 			arrival_or_departure = 0.0
 			accommodation = 0.0
 
-			days_rates = (
-				next(
-					rate
-					for rate in allowance_rates
-					if rate.valid_from <= frappe.utils.getdate(allowance.date)
-				)
-				if allowance_rates
-				else None
-			)
+			allowance_rates = _get_allowance_rates(self.region, allowance.date)
+			days_rates = allowance_rates[0] if allowance_rates else None
 
 			if days_rates:
 				whole_day = days_rates.whole_day
@@ -208,13 +199,10 @@ def get_meal_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> l
 	for allowance in business_trip.allowances:
 		description = "Ganztägig" if allowance.whole_day else "An-/Abreise"
 
+		accommodation = 0.0
 		allowance_rates = _get_allowance_rates(business_trip.region, allowance.date)
 		if allowance_rates:
-			accommodation = next(
-				rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
-			).accommodation
-		else:
-			accommodation = 0.0
+			accommodation = allowance_rates[0].accommodation
 
 		if not allowance.accommodation_was_provided and accommodation:
 			description += ", zzgl. Hotel"

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -10,9 +10,6 @@ from frappe.utils.data import fmt_money
 DEFAULT_EXPENSE_CLAIM_TYPE = "Additional meal expenses"
 
 if TYPE_CHECKING:
-	from erpnext_germany.erpnext_germany.doctype.business_trip_region.business_trip_region import (
-		BusinessTripRegion,
-	)
 	from erpnext_germany.erpnext_germany.doctype.business_trip_settings.business_trip_settings import (
 		BusinessTripSettings,
 	)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -283,7 +283,11 @@ def get_processing_details(business_trip: str):
 
 
 def _get_allowance_rates(region: str, date: str) -> list[_dict]:
-	return frappe.db.get_all(
+	"""Return allowance rates for a region valid on or before a date.
+
+	Results are ordered by `valid_from` in descending order so the most recent applicable rate is first.
+	"""
+	return frappe.get_all(
 		"Business Trip Region Allowance",
 		filters={
 			"parent": region,

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -75,12 +75,24 @@ class BusinessTrip(Document):
 		allowance_rates = _get_allowance_rates(self.region, self.to_date)
 
 		for allowance in self.allowances:
-			days_rates = next(
-				rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
+			whole_day = 0.0
+			arrival_or_departure = 0.0
+			accommodation = 0.0
+
+			days_rates = (
+				next(
+					rate
+					for rate in allowance_rates
+					if rate.valid_from <= frappe.utils.getdate(allowance.date)
+				)
+				if allowance_rates
+				else None
 			)
-			whole_day = days_rates.whole_day
-			arrival_or_departure = days_rates.arrival_or_departure
-			accommodation = days_rates.accommodation
+
+			if days_rates:
+				whole_day = days_rates.whole_day
+				arrival_or_departure = days_rates.arrival_or_departure
+				accommodation = days_rates.accommodation
 
 			amount = whole_day if allowance.whole_day else arrival_or_departure
 			if allowance.breakfast_was_provided:
@@ -195,9 +207,13 @@ def get_meal_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> l
 		description = "Ganztägig" if allowance.whole_day else "An-/Abreise"
 
 		allowance_rates = _get_allowance_rates(business_trip.region, allowance.date)
-		accommodation = next(
-			rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
-		).accommodation
+		if allowance_rates:
+			accommodation = next(
+				rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
+			).accommodation
+		else:
+			accommodation = 0.0
+
 		if not allowance.accommodation_was_provided and accommodation:
 			description += ", zzgl. Hotel"
 

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -10,6 +10,8 @@ from frappe.utils.data import fmt_money
 DEFAULT_EXPENSE_CLAIM_TYPE = "Additional meal expenses"
 
 if TYPE_CHECKING:
+	from frappe import _dict
+
 	from erpnext_germany.erpnext_germany.doctype.business_trip_settings.business_trip_settings import (
 		BusinessTripSettings,
 	)
@@ -280,7 +282,7 @@ def get_processing_details(business_trip: str):
 	return combined_records
 
 
-def _get_allowance_rates(region: str, date: str) -> list[dict]:
+def _get_allowance_rates(region: str, date: str) -> list[_dict]:
 	return frappe.db.get_all(
 		"Business Trip Region Allowance",
 		filters={

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -75,12 +75,16 @@ class BusinessTrip(Document):
 		if not self.region:
 			return
 
-		region: BusinessTripRegion = frappe.get_doc("Business Trip Region", self.region)
-		whole_day = region.whole_day or 0.0
-		arrival_or_departure = region.arrival_or_departure or 0.0
-		accomodation = region.accommodation or 0.0
+		allowance_rates = _get_allowance_rates(self.region, self.to_date)
 
 		for allowance in self.allowances:
+			days_rates = next(
+				rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
+			)
+			whole_day = days_rates.whole_day
+			arrival_or_departure = days_rates.arrival_or_departure
+			accomodation = days_rates.accommodation
+
 			amount = whole_day if allowance.whole_day else arrival_or_departure
 			if allowance.breakfast_was_provided:
 				amount -= whole_day * 0.2
@@ -192,9 +196,12 @@ def get_meal_expenses(business_trip: BusinessTrip, expense_claim_type: str) -> l
 	expenses = []
 	for allowance in business_trip.allowances:
 		description = "Ganztägig" if allowance.whole_day else "An-/Abreise"
-		if not allowance.accommodation_was_provided and frappe.db.get_value(
-			"Business Trip Region", business_trip.region, "accommodation"
-		):
+
+		allowance_rates = _get_allowance_rates(business_trip.region, allowance.date)
+		accomodation = next(
+			rate for rate in allowance_rates if rate.valid_from <= frappe.utils.getdate(allowance.date)
+		).accommodation
+		if not allowance.accommodation_was_provided and accomodation:
 			description += ", zzgl. Hotel"
 
 		if allowance.breakfast_was_provided:
@@ -258,3 +265,15 @@ def get_processing_details(business_trip: str):
 		combined_records.append(invoice)
 
 	return combined_records
+
+
+def _get_allowance_rates(region: str, date: str) -> list[dict]:
+	return frappe.db.get_all(
+		"Business Trip Region Allowance",
+		filters={
+			"parent": region,
+			"valid_from": ["<=", date],
+		},
+		order_by="valid_from DESC",
+		fields=["valid_from", "whole_day", "arrival_or_departure", "accommodation"],
+	)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -10,8 +10,6 @@ from frappe.utils.data import fmt_money
 DEFAULT_EXPENSE_CLAIM_TYPE = "Additional meal expenses"
 
 if TYPE_CHECKING:
-	from frappe import _dict
-
 	from erpnext_germany.erpnext_germany.doctype.business_trip_settings.business_trip_settings import (
 		BusinessTripSettings,
 	)
@@ -270,7 +268,7 @@ def get_processing_details(business_trip: str):
 	return combined_records
 
 
-def _get_allowance_rates(region: str, date: str) -> list[_dict]:
+def _get_allowance_rates(region: str, date: str):
 	"""Return allowance rates for a region valid on or before a date.
 
 	Results are ordered by `valid_from` in descending order so the most recent applicable rate is first.

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
@@ -7,45 +7,16 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
-  "whole_day",
-  "arrival_or_departure",
-  "accommodation",
   "column_break_ajul",
-  "valid_from",
-  "disabled"
+  "disabled",
+  "section_break_xukx",
+  "allowances"
  ],
  "fields": [
   {
    "fieldname": "title",
    "fieldtype": "Data",
    "label": "Title"
-  },
-  {
-   "description": "For an absence of at least 24 hours per calendar day",
-   "fieldname": "whole_day",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Whole Day"
-  },
-  {
-   "description": "For the day of arrival and departure and for an absence of more than 8 hours per calendar day",
-   "fieldname": "arrival_or_departure",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Arrival or Departure"
-  },
-  {
-   "description": "Lump sum for accommodation expenses",
-   "fieldname": "accommodation",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Accommodation"
-  },
-  {
-   "fieldname": "valid_from",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Valid From"
   },
   {
    "fieldname": "column_break_ajul",
@@ -56,8 +27,20 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "fieldname": "section_break_xukx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "allowances",
+   "fieldtype": "Table",
+   "label": "Allowances",
+   "options": "Business Trip Region Allowance",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [
   {
@@ -65,7 +48,7 @@
    "link_fieldname": "region"
   }
  ],
- "modified": "2024-10-24 22:42:37.127349",
+ "modified": "2025-12-22 16:37:42.936069",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Region",
@@ -95,7 +78,7 @@
    "write": 1
   }
  ],
- "search_fields": "valid_from",
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "hash",
+ "autoname": "field:title",
  "creation": "2022-11-01 20:24:28.877901",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -54,7 +54,6 @@
  "module": "ERPNext Germany",
  "name": "Business Trip Region",
  "naming_rule": "By fieldname",
- "autoname": "field:title",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "field:title",
+ "autoname": "hash",
  "creation": "2022-11-01 20:24:28.877901",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -16,6 +16,7 @@
   {
    "fieldname": "title",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Title",
    "reqd": 1
   },
@@ -49,11 +50,11 @@
    "link_fieldname": "region"
   }
  ],
- "modified": "2025-12-22 17:25:42.936069",
+ "modified": "2026-01-19 16:42:23.130520",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Region",
- "naming_rule": "By fieldname",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -83,5 +84,6 @@
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "title"
 }

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
@@ -16,7 +16,8 @@
   {
    "fieldname": "title",
    "fieldtype": "Data",
-   "label": "Title"
+   "label": "Title",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_ajul",
@@ -48,11 +49,12 @@
    "link_fieldname": "region"
   }
  ],
- "modified": "2025-12-22 16:37:42.936069",
+ "modified": "2025-12-22 17:25:42.936069",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Region",
- "naming_rule": "Random",
+ "naming_rule": "By fieldname",
+ "autoname": "field:title",
  "owner": "Administrator",
  "permissions": [
   {
@@ -82,6 +84,5 @@
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
- "title_field": "title"
+ "states": []
 }

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -22,4 +23,7 @@ class BusinessTripRegion(Document):
 		disabled: DF.Check
 		title: DF.Data | None
 	# end: auto-generated types
-	pass
+
+	def validate(self):
+		if len(set(allowance.valid_from for allowance in self.allowances)) != len(self.allowances):
+			frappe.throw(_("There are multiple allowance rows with the same Valid From date."))

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -12,8 +12,11 @@ class BusinessTripRegion(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import BusinessTripRegionAllowance
 		from frappe.types import DF
+
+		from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import (
+			BusinessTripRegionAllowance,
+		)
 
 		allowances: DF.Table[BusinessTripRegionAllowance]
 		disabled: DF.Check

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -14,7 +14,7 @@ class BusinessTripRegion(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import (
+		from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import (  # noqa: E501
 			BusinessTripRegionAllowance,
 		)
 

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -21,7 +21,7 @@ class BusinessTripRegion(Document):
 
 		allowances: DF.Table[BusinessTripRegionAllowance]
 		disabled: DF.Check
-		title: DF.Data | None
+		title: DF.Data
 	# end: auto-generated types
 
 	def validate(self):

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
@@ -1,0 +1,59 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-12-22 16:33:46.478777",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "valid_from",
+  "whole_day",
+  "arrival_or_departure",
+  "accommodation"
+ ],
+ "fields": [
+  {
+   "fieldname": "valid_from",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Valid From",
+   "reqd": 1
+  },
+  {
+   "fieldname": "whole_day",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Whole Day",
+   "reqd": 1
+  },
+  {
+   "fieldname": "arrival_or_departure",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Arrival or Departure",
+   "reqd": 1
+  },
+  {
+   "fieldname": "accommodation",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Accommodation",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-12-22 16:36:19.657408",
+ "modified_by": "Administrator",
+ "module": "ERPNext Germany",
+ "name": "Business Trip Region Allowance",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
@@ -1,22 +1,25 @@
-# Copyright (c) 2024, ALYF GmbH and contributors
+# Copyright (c) 2025, ALYF GmbH and contributors
 # For license information, please see license.txt
 
 # import frappe
 from frappe.model.document import Document
 
 
-class BusinessTripRegion(Document):
+class BusinessTripRegionAllowance(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext_germany.erpnext_germany.doctype.business_trip_region_allowance.business_trip_region_allowance import BusinessTripRegionAllowance
 		from frappe.types import DF
 
-		allowances: DF.Table[BusinessTripRegionAllowance]
-		disabled: DF.Check
-		title: DF.Data | None
+		accommodation: DF.Currency
+		arrival_or_departure: DF.Currency
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		valid_from: DF.Date
+		whole_day: DF.Currency
 	# end: auto-generated types
 	pass

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -13,4 +13,4 @@ execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_
 erpnext_germany.patches.set_business_trip_settings
 erpnext_germany.patches.remove_some_employee_property_setters
 execute:from erpnext_germany.install import make_property_setters; make_property_setters()
-erpnext_germany.patches.move_business_trip_region_data_to_child_table
+erpnext_germany.patches.move_business_trip_region_data_to_child_table #2

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -13,3 +13,4 @@ execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_
 erpnext_germany.patches.set_business_trip_settings
 erpnext_germany.patches.remove_some_employee_property_setters
 execute:from erpnext_germany.install import make_property_setters; make_property_setters()
+erpnext_germany.patches.move_business_trip_region_data_to_child_table

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -23,7 +23,7 @@ def execute():
 		doc.save()
 
 		# Step 2: Rename documents.
-		# Since the valid_from field based on the child table, there is no more need
+		# Since the valid_from field is based on the child table, there is no more need
 		# for several documents with the same title.
 		# Therefore, the title should be used as the new name.
 		try:

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -14,10 +14,10 @@ def execute():
 		doc.append(
 			"allowances",
 			{
-				"valid_from": doc.valid_from or "2000-01-01",
-				"whole_day": doc.whole_day or 0.0,
-				"arrival_or_departure": doc.arrival_or_departure or 0.0,
-				"accommodation": doc.accommodation or 0.0,
+				"valid_from": doc.get("valid_from") or "2000-01-01",
+				"whole_day": doc.get("whole_day") or 0.0,
+				"arrival_or_departure": doc.get("arrival_or_departure") or 0.0,
+				"accommodation": doc.get("accommodation") or 0.0,
 			},
 		)
 		doc.save()

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -4,12 +4,13 @@ import frappe
 def execute():
 	"""
 	Move the data from the old fields (on doc level) to the new child table.
+	And rename the documents.
 	"""
-	for business_trip_region_id in frappe.get_all("Business Trip Region", filters={"disabled": 0}, pluck="name"):
+	regions = frappe.get_all("Business Trip Region", filters={"disabled": 0}, pluck="name")
+	for business_trip_region_id in regions:
 		doc = frappe.get_doc("Business Trip Region", business_trip_region_id)
-		if doc.allowances:
-			continue
 
+		# Step 1: Move the data to the child table.
 		doc.append(
 			"allowances",
 			{
@@ -20,3 +21,11 @@ def execute():
 			}
 		)
 		doc.save()
+
+		# Step 2: Rename documents.
+		# Since the valid_from field based on the child table, there is no more need for several documents with the same title.
+		# Therefore, the title should be used as the new name.
+		try:
+			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True)
+		except Exception as e:
+			frappe.log_error(e)

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -23,7 +23,8 @@ def execute():
 		doc.save()
 
 		# Step 2: Rename documents.
-		# Since the valid_from field based on the child table, there is no more need for several documents with the same title.
+		# Since the valid_from field based on the child table, there is no more need
+		# for several documents with the same title.
 		# Therefore, the title should be used as the new name.
 		try:
 			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True)

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	"""
+	Move the data from the old fields (on doc level) to the new child table.
+	"""
+	for business_trip_region_id in frappe.get_all("Business Trip Region", filters={"disabled": 0}, pluck="name"):
+		doc = frappe.get_doc("Business Trip Region", business_trip_region_id)
+		if doc.allowances:
+			continue
+
+		doc.append(
+			"allowances",
+			{
+				"valid_from": doc.valid_from or "2000-01-01",
+				"whole_day": doc.whole_day or 0.0,
+				"arrival_or_departure": doc.arrival_or_departure or 0.0,
+				"accommodation": doc.accommodation or 0.0,
+			}
+		)
+		doc.save()

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -28,5 +28,16 @@ def execute():
 		# Therefore, the title should be used as the new name.
 		try:
 			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True)
+		except frappe.DuplicateEntryError as e:
+			# Duplicate titles are expected in some cases; log with context and continue.
+			frappe.log_error(
+				message=f"Duplicate title while renaming Business Trip Region '{business_trip_region_id}' to '{doc.title}': {e}",
+				title="Business Trip Region rename skipped due to duplicate title",
+			)
 		except Exception as e:
-			frappe.log_error(e)
+			# Unexpected errors should be logged with context and re-raised.
+			frappe.log_error(
+				message=f"Unexpected error while renaming Business Trip Region '{business_trip_region_id}' to '{doc.title}': {e}",
+				title="Business Trip Region rename failed",
+			)
+			raise

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -6,7 +6,7 @@ def execute():
 	Move the data from the old fields (on doc level) to the new child table.
 	And rename the documents.
 	"""
-	regions = frappe.get_all("Business Trip Region", filters={"disabled": 0}, pluck="name")
+	regions = frappe.get_all("Business Trip Region", pluck="name")
 	for business_trip_region_id in regions:
 		doc = frappe.get_doc("Business Trip Region", business_trip_region_id)
 

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -1,11 +1,9 @@
 import frappe
-from frappe import _
 
 
 def execute():
 	"""
 	Move the data from the old fields (on doc level) to the new child table.
-	And rename the documents.
 	"""
 	regions = frappe.get_all("Business Trip Region", pluck="name")
 	for business_trip_region_id in regions:
@@ -22,29 +20,3 @@ def execute():
 			},
 		)
 		doc.save()
-
-		# Step 2: Rename documents.
-		# Since the valid_from field is based on the child table, there is no more need
-		# for several documents with the same title.
-		# Therefore, the title should be used as the new name.
-		try:
-			frappe.rename_doc(
-				"Business Trip Region", business_trip_region_id, doc.title, force=True, merge=True
-			)
-		except frappe.DuplicateEntryError as e:
-			# Duplicate titles are expected in some cases; log with context and continue.
-			frappe.log_error(
-				message=_("Duplicate title while renaming Business Trip Region '{0}' to '{1}': {2}").format(
-					business_trip_region_id, doc.title, e
-				),
-				title="Business Trip Region rename skipped due to duplicate title",
-			)
-		except Exception as e:
-			# Unexpected errors should be logged with context and re-raised.
-			frappe.log_error(
-				message=_("Unexpected error while renaming Business Trip Region '{0}' to '{1}': {2}").format(
-					business_trip_region_id, doc.title, e
-				),
-				title="Business Trip Region rename failed",
-			)
-			raise

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -18,7 +18,7 @@ def execute():
 				"whole_day": doc.whole_day or 0.0,
 				"arrival_or_departure": doc.arrival_or_departure or 0.0,
 				"accommodation": doc.accommodation or 0.0,
-			}
+			},
 		)
 		doc.save()
 

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -27,7 +27,7 @@ def execute():
 		# for several documents with the same title.
 		# Therefore, the title should be used as the new name.
 		try:
-			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True)
+			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True, merge=True)
 		except frappe.DuplicateEntryError as e:
 			# Duplicate titles are expected in some cases; log with context and continue.
 			frappe.log_error(

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -27,7 +27,9 @@ def execute():
 		# for several documents with the same title.
 		# Therefore, the title should be used as the new name.
 		try:
-			frappe.rename_doc("Business Trip Region", business_trip_region_id, doc.title, force=True, merge=True)
+			frappe.rename_doc(
+				"Business Trip Region", business_trip_region_id, doc.title, force=True, merge=True
+			)
 		except frappe.DuplicateEntryError as e:
 			# Duplicate titles are expected in some cases; log with context and continue.
 			frappe.log_error(

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 
 def execute():
@@ -33,13 +34,17 @@ def execute():
 		except frappe.DuplicateEntryError as e:
 			# Duplicate titles are expected in some cases; log with context and continue.
 			frappe.log_error(
-				message=f"Duplicate title while renaming Business Trip Region '{business_trip_region_id}' to '{doc.title}': {e}",
+				message=_("Duplicate title while renaming Business Trip Region '{0}' to '{1}': {2}").format(
+					business_trip_region_id, doc.title, e
+				),
 				title="Business Trip Region rename skipped due to duplicate title",
 			)
 		except Exception as e:
 			# Unexpected errors should be logged with context and re-raised.
 			frappe.log_error(
-				message=f"Unexpected error while renaming Business Trip Region '{business_trip_region_id}' to '{doc.title}': {e}",
+				message=_("Unexpected error while renaming Business Trip Region '{0}' to '{1}': {2}").format(
+					business_trip_region_id, doc.title, e
+				),
 				title="Business Trip Region rename failed",
 			)
 			raise


### PR DESCRIPTION
Solves: https://github.com/alyf-de/erpnext_germany/issues/95 

Addition: 
Since there is no more `valid_from` in **Business Trip Region**, but in **Business Trip Region Allowance**, the title of a **Business Trip Region** should be unique. The region itself now can show different rates on the child table level.
Therefore the naming of **Business Trip Region** is changed and the documents were renamed via patch.