### PR TITLE
fix(Business Trip): filter by valid_from

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js
@@ -6,9 +6,7 @@ frappe.ui.form.on("Business Trip", {
 		frm.set_query("employee", erpnext.queries.employee);
 		frm.set_query("region", (doc) => {
 			return {
-				filters: {
-					valid_from: ["<=", doc.from_date],
-				},
+				filters: [["Business Trip Region Allowance", "valid_from", "<=", doc.from_date]],
 			};
 		});
 	},


### PR DESCRIPTION
Updated the `frm.set_query` filter for the `region` field to use a table-based filter format, ensuring that only `Business Trip Region Allowance` records with a `valid_from` date on or before the trip's `from_date` are shown.

This was missing in #106