### PR TITLE
fix(Business Trip Region): import current data

### DIFF
--- a/erpnext_germany/data/business_trip_region.csv
+++ b/erpnext_germany/data/business_trip_region.csv
@@ -1,18 +1,21 @@
-title,whole_day,arrival_or_departure,accommodation,valid_from
+title,whole_day,arrival_or_departure,accommodation,valid_from,valid_to
 Afghanistan,30,20,95,2024-01-01
 Ägypten,50,33,112,2024-01-01
-Äthiopien,39,26,130,2024-01-01
-Äquatorialguinea,42,28,166,2024-01-01
 Albanien,27,18,112,2024-01-01
+Albanien,33,22,116,2026-01-01
 Algerien,47,32,120,2024-01-01
 Andorra,41,28,91,2024-01-01
+Andorra,45,30,135,2026-01-01
 Angola,52,35,299,2024-01-01
+Äquatorialguinea,42,28,166,2024-01-01
 Argentinien,35,24,113,2024-01-01
+Argentinien,42,28,119,2026-01-01
 Armenien,24,16,59,2024-01-01
 Aserbaidschan,44,29,88,2024-01-01
+Äthiopien,39,26,130,2024-01-01
+Australien,57,38,173,2024-01-01
 Australien: Canberra,74,49,186,2024-01-01
 Australien: Sydney,57,38,173,2024-01-01
-Australien,57,38,173,2024-01-01
 Bahrain,48,32,153,2024-01-01
 Bangladesch,50,33,165,2024-01-01
 Barbados,54,36,206,2024-01-01
@@ -20,24 +23,34 @@ Belgien,59,40,141,2024-01-01
 Benin,52,35,115,2024-01-01
 Bolivien,46,31,108,2024-01-01
 Bosnien und Herzegowina,23,16,75,2024-01-01
+Bosnien und Herzegowina,32,21,109,2026-01-01
+Botsuana,40,27,105,2026-01-01
 Botsuana,46,31,176,2024-01-01
+Brasilien,46,31,88,2024-01-01
 Brasilien: Brasilia,51,34,88,2024-01-01
 Brasilien: Rio de Janeiro,69,46,140,2024-01-01
 Brasilien: Sao Paulo,46,31,151,2024-01-01
-Brasilien,46,31,88,2024-01-01
 Brunei,52,35,106,2024-01-01
 Bulgarien,22,15,115,2024-01-01
+Bulgarien,38,25,109,2026-01-01
 Burkina Faso,38,25,174,2024-01-01
+Burkina Faso,39,26,230,2026-01-01
 Burundi,36,24,138,2024-01-01
+Burundi,58,39,102,2026-01-01
 Chile,44,29,154,2024-01-01
-China: Chengdu,41,28,131,2024-01-01
-China: Hongkong,71,48,169,2024-01-01
-China: Kanton,36,24,150,2024-01-01
-China: Peking,30,20,185,2024-01-01
-China: Shanghai,58,39,217,2024-01-01
 China,48,32,112,2024-01-01
+China,48,32,142,2026-01-01
+China: Chengdu,41,28,131,2024-01-01,2025-12-31
+China: Hongkong,71,48,169,2024-01-01
+China: Hongkong,83,56,209,2026-01-01
+China: Kanton,36,24,150,2024-01-01,2025-12-31
+China: Peking,30,20,185,2024-01-01
+China: Peking,57,38,184,2026-01-01
+China: Shanghai,48,32,142,2026-01-01
+China: Shanghai,58,39,217,2024-01-01
 Costa Rica,47,32,93,2024-01-01
 Côte d’Ivoire,59,40,166,2024-01-01
+Côte d’Ivoire,60,40,171,2026-01-01
 Dänemark,75,50,183,2024-01-01
 Deutschland,28,14,0,2024-01-01
 Dominikanische Republik,50,33,167,2024-01-01
@@ -46,77 +59,93 @@ Ecuador,27,18,103,2024-01-01
 El Salvador,65,44,161,2024-01-01
 Eritrea,50,33,91,2024-01-01
 Estland,29,20,85,2024-01-01
+Estland,39,26,125,2026-01-01
 Fidschi,32,21,183,2024-01-01
 Finnland,54,36,171,2024-01-01
-"Frankreich: Paris sowie die Departments 77, 78, 91 bis 95",58,39,159,2024-01-01
 Frankreich,53,36,105,2024-01-01
+"Frankreich: Paris sowie die Departments 77, 78, 91 bis 95",58,39,159,2024-01-01
 Gabun,52,35,183,2024-01-01
 Gambia,40,27,161,2024-01-01
 Georgien,45,30,87,2024-01-01
 Ghana,46,31,148,2024-01-01
-Griechenland: Athen,40,27,139,2024-01-01
 Griechenland,36,24,150,2024-01-01
+Griechenland: Athen,40,27,139,2024-01-01
 Guatemala,34,23,90,2024-01-01
-Guinea,59,40,140,2024-01-01
 Guinea-Bissau,32,21,113,2024-01-01
+Guinea,59,40,140,2024-01-01
 Haiti,58,39,130,2024-01-01
 Honduras,57,38,198,2024-01-01
+Indien,32,21,85,2024-01-01
 Indien: Chennai,32,21,85,2024-01-01
 Indien: Kalkutta,35,24,145,2024-01-01
 Indien: Mumbai,50,33,146,2024-01-01
 Indien: Neu Delhi,38,25,185,2024-01-01
-Indien,32,21,85,2024-01-01
 Indonesien,36,24,134,2024-01-01
 Iran,33,22,196,2024-01-01
 Irland,58,39,129,2024-01-01
+Irland,64,43,164,2026-01-01
 Island,62,41,187,2024-01-01
+Israel,59,40,268,2026-01-01
 Israel,66,44,190,2024-01-01
+Italien,42,28,150,2024-01-01
 Italien: Mailand,42,28,191,2024-01-01
 Italien: Rom,48,32,150,2024-01-01
-Italien,42,28,150,2024-01-01
 Jamaika,39,26,171,2024-01-01
-Japan: Tokio,50,33,285,2024-01-01
 Japan,52,35,190,2024-01-01
+Japan: Tokio,50,33,285,2024-01-01
 Jemen,24,16,95,2024-01-01
 Jordanien,57,38,134,2024-01-01
 Kambodscha,38,25,94,2024-01-01
 Kamerun,56,37,275,2024-01-01
+Kanada,54,36,214,2024-01-01
 Kanada: Ottawa,62,41,214,2024-01-01
 Kanada: Toronto,54,36,392,2024-01-01
 Kanada: Vancouver,63,42,304,2024-01-01
-Kanada,54,36,214,2024-01-01
 Kap Verde,38,25,90,2024-01-01
 Kasachstan,45,30,111,2024-01-01
 Katar,56,37,149,2024-01-01
+Katar,81,54,128,2026-01-01
+Kenia,48,32,217,2026-01-01
 Kenia,51,34,219,2024-01-01
 Kirgisistan,27,18,74,2024-01-01
+Kirgisistan,35,24,80,2026-01-01
 Kolumbien,46,31,115,2024-01-01
-"Kongo, Republik",62,41,215,2024-01-01
 "Kongo, Demokratische Republik",70,47,190,2024-01-01
+"Kongo, Republik",62,41,215,2024-01-01
+"Kongo, Republik",53,36,215,2026-01-01
 "Korea, Demokratische Volksrepublik",28,19,92,2024-01-01
+"Korea, Republik",39,26,130,2026-01-01
 "Korea, Republik",48,32,108,2024-01-01
 Kosovo,24,16,71,2024-01-01
 Kroatien,35,24,107,2024-01-01
 Kuba,51,34,170,2024-01-01
 Kuwait,56,37,241,2024-01-01
+Kuwait,63,42,224,2026-01-01
 Laos,35,24,71,2024-01-01
 Lesotho,28,19,104,2024-01-01
 Lettland,35,24,76,2024-01-01
+Lettland,46,31,119,2026-01-01
 Libanon,69,46,146,2024-01-01
 Libyen,63,42,135,2024-01-01
 Liechtenstein,56,37,190,2024-01-01
+Liechtenstein,57,38,234,2026-01-01
 Litauen,26,17,109,2024-01-01
+Litauen,48,32,124,2026-01-01
 Luxemburg,63,42,139,2024-01-01
 Madagaskar,33,22,116,2024-01-01
 Malawi,41,28,109,2024-01-01
 Malaysia,36,24,86,2024-01-01
 Malediven,52,35,170,2024-01-01
 Mali,38,25,120,2024-01-01
+Mali,45,28,141,2026-01-01
 Malta,46,31,114,2024-01-01
+Malta,59,40,191,2026-01-01
 Marokko,41,28,87,2024-01-01
+Marshall Inseln,45,30,112,2026-01-01
 Marshall Inseln,63,42,102,2024-01-01
 Mauretanien,35,24,86,2024-01-01
 Mauritius,44,29,172,2024-01-01
+Mexiko,40,27,337,2026-01-01
 Mexiko,48,32,177,2024-01-01
 "Moldau, Republik",26,17,73,2024-01-01
 Monaco,52,35,187,2024-01-01
@@ -124,89 +153,107 @@ Mongolei,23,16,92,2024-01-01
 Montenegro,32,21,85,2024-01-01
 Mosambik,51,34,208,2024-01-01
 Myanmar,35,24,155,2024-01-01
+Namibia,28,19,146,2026-01-01
 Namibia,30,20,112,2024-01-01
+Nepal,33,22,125,2026-01-01
 Nepal,36,24,126,2024-01-01
 Neuseeland,58,39,148,2024-01-01
 Nicaragua,46,31,105,2024-01-01
 Niederlande,47,32,122,2024-01-01
+Niederlande,58,39,167,2026-01-01
 Niger,42,28,131,2024-01-01
 Nigeria,46,31,182,2024-01-01
+Nigeria,52,35,202,2026-01-01
 Nordmazedonien,27,18,89,2024-01-01
 Norwegen,75,50,139,2024-01-01
-Österreich,50,33,117,2024-01-01
 Oman,64,43,141,2024-01-01
-Pakistan: Islamabad,23,16,238,2024-01-01
+Österreich,50,33,117,2024-01-01
 Pakistan,34,23,122,2024-01-01
+Pakistan,41,28,199,2026-01-01
+Pakistan: Islamabad,23,16,238,2024-01-01
 Palau,51,34,179,2024-01-01
 Panama,41,28,82,2024-01-01
 Papua-Neuguinea,59,40,159,2024-01-01
 Paraguay,39,26,124,2024-01-01
 Peru,34,23,143,2024-01-01
+Peru,52,35,128,2026-01-01
 Philippinen,41,28,140,2024-01-01
+Polen,29,20,60,2024-01-01
 Polen: Breslau,33,22,117,2024-01-01
 Polen: Danzig,30,20,84,2024-01-01
 Polen: Krakau,27,18,86,2024-01-01
 Polen: Warschau,29,20,109,2024-01-01
-Polen,29,20,60,2024-01-01
 Portugal,32,21,111,2024-01-01
 Ruanda,44,29,117,2024-01-01
-Rumänien: Bukarest,32,21,92,2024-01-01
 Rumänien,27,18,89,2024-01-01
+Rumänien,38,25,103,2026-01-01
+Rumänien: Bukarest,32,21,92,2024-01-01
+Russische Föderation,24,16,58,2024-01-01
 Russische Föderation: Jekaterinburg,28,19,84,2024-01-01
 Russische Föderation: Moskau,30,20,110,2024-01-01
 Russische Föderation: St. Petersburg,26,17,114,2024-01-01
-Russische Föderation,24,16,58,2024-01-01
 Sambia,38,25,105,2024-01-01
 Samoa,39,26,105,2024-01-01
 San Marino,34,23,79,2024-01-01
 São Tomé – Príncipe,47,32,80,2024-01-01
+Saudi-Arabien,56,37,181,2024-01-01
 Saudi-Arabien: Djidda,57,38,181,2024-01-01
 Saudi-Arabien: Riad,56,37,186,2024-01-01
-Saudi-Arabien,56,37,181,2024-01-01
 Schweden,66,44,140,2024-01-01
-Schweiz: Genf,66,44,186,2024-01-01
 Schweiz,64,43,180,2024-01-01
+Schweiz,70,47,195,2026-01-01
+Schweiz: Bern,82,55,195,2026-01-01
+Schweiz: Genf,66,44,186,2024-01-01
+Schweiz: Genf,70,47,197,2026-01-01
 Senegal,42,28,190,2024-01-01
+Senegal,48,32,160,2026-01-01
 Serbien,27,18,97,2024-01-01
 Sierra Leone,57,38,145,2024-01-01
 Simbabwe,45,30,140,2024-01-01
 Singapur,54,36,197,2024-01-01
 Slowakische Republik,33,22,121,2024-01-01
 Slowenien,38,25,126,2024-01-01
+Spanien,34,23,103,2024-01-01
 Spanien: Barcelona,34,23,144,2024-01-01
 Spanien: Kanarische Inseln,36,24,103,2024-01-01
 Spanien: Madrid,42,28,131,2024-01-01
 Spanien: Palma de Mallorca,44,29,142,2024-01-01
-Spanien,34,23,103,2024-01-01
 Sri Lanka,36,24,112,2024-01-01
-Sudan,33,22,195,2024-01-01
-Südafrika: Kapstadt,33,22,130,2024-01-01
-Südafrika: Johannesburg,36,24,129,2024-01-01
 Südafrika,29,20,109,2024-01-01
+Südafrika: Johannesburg,36,24,129,2024-01-01
+Südafrika: Kapstadt,33,22,130,2024-01-01
+Sudan,33,22,195,2024-01-01
 Südsudan,51,34,159,2024-01-01
 Syrien,38,25,140,2024-01-01
 Tadschikistan,27,18,118,2024-01-01
 Taiwan,46,31,143,2024-01-01
 Tansania,44,29,97,2024-01-01
 Thailand,38,25,110,2024-01-01
+Togo,36,24,144,2026-01-01
 Togo,39,26,118,2024-01-01
 Tonga,39,26,94,2024-01-01
 Trinidad und Tobago,66,44,203,2024-01-01
 Tschad,42,28,155,2024-01-01
 Tschechische Republik,32,21,77,2024-01-01
+Tunesien,40,27,144,2024-01-01
+Türkei,17,12,95,2024-01-01
 Türkei: Istanbul,26,17,120,2024-01-01
 Türkei: Izmir,29,20,55,2024-01-01
-Türkei,17,12,95,2024-01-01
-Tunesien,40,27,144,2024-01-01
 Turkmenistan,33,22,108,2024-01-01
 Uganda,41,28,143,2024-01-01
+Uganda,45,30,207,2026-01-01
 Ukraine,26,17,98,2024-01-01
+Ukraine,33,22,180,2026-01-01
 Ungarn,32,21,85,2024-01-01
 Uruguay,48,32,90,2024-01-01
+Usbekistan,32,21,133,2026-01-01
 Usbekistan,34,23,104,2024-01-01
 Vatikanstaat,48,32,150,2024-01-01
 Venezuela,45,30,127,2024-01-01
+Venezuela,51,34,178,2026-01-01
 Vereinigte Arabische Emirate,65,44,156,2024-01-01
+Vereinigte Arabische Emirate,81,54,169,2026-01-01
+Vereinigte Staaten von Amerika,59,40,182,2024-01-01
 Vereinigte Staaten von Amerika: Atlanta,77,52,182,2024-01-01
 Vereinigte Staaten von Amerika: Boston,63,42,333,2024-01-01
 Vereinigte Staaten von Amerika: Chicago,65,44,233,2024-01-01
@@ -216,10 +263,10 @@ Vereinigte Staaten von Amerika: Miami,65,44,256,2024-01-01
 Vereinigte Staaten von Amerika: New York City,66,44,308,2024-01-01
 Vereinigte Staaten von Amerika: San Francisco,59,40,327,2024-01-01
 "Vereinigte Staaten von Amerika: Washington, D. C.",66,44,203,2024-01-01
-Vereinigte Staaten von Amerika,59,40,182,2024-01-01
-Vereinigtes Königreich von Großbritannien und Nordirland: London,66,44,163,2024-01-01
 Vereinigtes Königreich von Großbritannien und Nordirland,52,35,99,2024-01-01
+Vereinigtes Königreich von Großbritannien und Nordirland: London,66,44,163,2024-01-01
 Vietnam,41,28,86,2024-01-01
 Weißrussland,20,13,98,2024-01-01
+Weißrussland,21,14,148,2026-01-01
 Zentralafrikanische Republik,53,36,210,2024-01-01
 Zypern,42,28,125,2024-01-01

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -279,6 +279,10 @@ def _get_allowance_rates(region: str, date: str):
 			"parent": region,
 			"valid_from": ["<=", date],
 		},
+		or_filters=[
+			["valid_to", "is", "not set"],
+			["valid_to", ">=", date],
+		],
 		order_by="valid_from DESC",
 		fields=["valid_from", "whole_day", "arrival_or_departure", "accommodation"],
 	)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py
@@ -27,3 +27,6 @@ class BusinessTripRegion(Document):
 	def validate(self):
 		if len(set(allowance.valid_from for allowance in self.allowances)) != len(self.allowances):
 			frappe.throw(_("There are multiple allowance rows with the same Valid From date."))
+
+		for allowance in self.allowances:
+			allowance.validate()

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "valid_from",
+  "valid_to",
   "whole_day",
   "arrival_or_departure",
   "accommodation"
@@ -39,13 +40,18 @@
    "in_list_view": 1,
    "label": "Accommodation",
    "reqd": 1
+  },
+  {
+   "fieldname": "valid_to",
+   "fieldtype": "Date",
+   "label": "Valid To"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-12-22 16:36:19.657408",
+ "modified": "2026-01-30 13:43:42.427782",
  "modified_by": "Administrator",
  "module": "ERPNext Germany",
  "name": "Business Trip Region Allowance",

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
@@ -1,65 +1,69 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2025-12-22 16:33:46.478777",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "valid_from",
-  "valid_to",
-  "whole_day",
-  "arrival_or_departure",
-  "accommodation"
- ],
- "fields": [
-  {
-   "fieldname": "valid_from",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Valid From",
-   "reqd": 1
-  },
-  {
-   "fieldname": "whole_day",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Whole Day",
-   "reqd": 1
-  },
-  {
-   "fieldname": "arrival_or_departure",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Arrival or Departure",
-   "reqd": 1
-  },
-  {
-   "fieldname": "accommodation",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Accommodation",
-   "reqd": 1
-  },
-  {
-   "fieldname": "valid_to",
-   "fieldtype": "Date",
-   "label": "Valid To"
-  }
- ],
- "grid_page_length": 50,
- "index_web_pages_for_search": 1,
- "istable": 1,
- "links": [],
- "modified": "2026-01-30 13:43:42.427782",
- "modified_by": "Administrator",
- "module": "ERPNext Germany",
- "name": "Business Trip Region Allowance",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "rows_threshold_for_grid_search": 20,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
-}
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2025-12-22 16:33:46.478777",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+     "valid_from",
+     "valid_to",
+     "whole_day",
+     "arrival_or_departure",
+     "accommodation"
+    ],
+    "fields": [
+     {
+      "fieldname": "valid_from",
+      "fieldtype": "Date",
+      "in_list_view": 1,
+      "label": "Valid From",
+      "reqd": 1
+     },
+     {
+      "description": "For an absence of at least 24 hours per calendar day",
+      "fieldname": "whole_day",
+      "fieldtype": "Currency",
+      "in_list_view": 1,
+      "label": "Whole Day",
+      "reqd": 1
+     },
+     {
+      "description": "For the day of arrival and departure and for an absence of more than 8 hours per calendar day",
+      "fieldname": "arrival_or_departure",
+      "fieldtype": "Currency",
+      "in_list_view": 1,
+      "label": "Arrival or Departure",
+      "reqd": 1
+     },
+     {
+      "description": "Lump sum for accommodation expenses",
+      "fieldname": "accommodation",
+      "fieldtype": "Currency",
+      "in_list_view": 1,
+      "label": "Accommodation",
+      "reqd": 1
+     },
+     {
+      "description": "A Valid To is not needed if these rates are replaced by a row with a newer Valid From date.\nSet the Valid To date only if this region's allowance is being retired and will not be replaced by a newer rate.",
+      "fieldname": "valid_to",
+      "fieldtype": "Date",
+      "label": "Valid To"
+     }
+    ],
+    "grid_page_length": 50,
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2026-01-30 16:32:34.099709",
+    "modified_by": "Administrator",
+    "module": "ERPNext Germany",
+    "name": "Business Trip Region Allowance",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "rows_threshold_for_grid_search": 20,
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
+   }

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.py
@@ -20,6 +20,9 @@ class BusinessTripRegionAllowance(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		valid_from: DF.Date
+		valid_to: DF.Date | None
 		whole_day: DF.Currency
 	# end: auto-generated types
-	pass
+
+	def validate(self):
+		self.validate_from_to_dates("valid_from", "valid_to")

--- a/erpnext_germany/install.py
+++ b/erpnext_germany/install.py
@@ -9,6 +9,7 @@ from frappe.custom.doctype.customize_form.customize_form import (
 )
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.exceptions import DuplicateEntryError
+from frappe.utils.data import getdate
 
 from .custom_fields import get_custom_fields
 from .property_setters import get_property_setters
@@ -22,32 +23,75 @@ def after_install():
 
 
 def import_data():
-	for doctype, filename in (
-		("Religious Denomination", "religious_denomination.csv"),
-		("Employee Health Insurance", "employee_health_insurance.csv"),
-		("Expense Claim Type", "expense_claim_type.csv"),
-		("Business Trip Region", "business_trip_region.csv"),
+	for doctype, filename, processor in (
+		("Religious Denomination", "religious_denomination.csv", generic_csv_import),
+		("Employee Health Insurance", "employee_health_insurance.csv", generic_csv_import),
+		("Expense Claim Type", "expense_claim_type.csv", generic_csv_import),
+		("Business Trip Region", "business_trip_region.csv", business_trip_region_csv_import),
 	):
 		if not frappe.db.exists("DocType", doctype):
 			continue
 
 		path = frappe.get_app_path("erpnext_germany", "data", filename)
-		import_csv(doctype, path)
+		import_csv(doctype, path, processor)
 
 
-def import_csv(doctype, path):
+def import_csv(doctype, path, processor):
 	with open(path) as csvfile:
 		reader = DictReader(csvfile)
 		for row in reader:
-			if frappe.db.exists(doctype, row):
-				# This doesn't catch all duplicates, because it expects all
-				# fields to match, not (only) the primary key.
-				continue
+			processor(doctype, row)
 
-			doc = frappe.new_doc(doctype)
-			doc.update(row)
-			with contextlib.suppress(DuplicateEntryError):
-				doc.insert()
+
+def generic_csv_import(doctype, row):
+	"""Import a simple CSV row that corresponds to a single record without child tables."""
+	if frappe.db.exists(doctype, row):
+		# This doesn't catch all duplicates, because it expects all
+		# fields to match, not (only) the primary key.
+		return
+
+	doc = frappe.new_doc(doctype)
+	doc.update(row)
+	with contextlib.suppress(DuplicateEntryError):
+		doc.insert()
+
+
+def business_trip_region_csv_import(doctype, row):
+	"""Import a Business Trip Region CSV row that corresponds to a child table entry.
+
+	If the parent record already exists, we append the new child table row to the existing record.
+	If the parent record does not exist, we create a new record.
+	"""
+	existing_record = frappe.db.get_value(doctype, {"title": row["title"]})
+	if existing_record:
+		region = frappe.get_doc(doctype, existing_record)
+	else:
+		region = frappe.new_doc(doctype)
+		region.title = row["title"]
+
+	row_valid_from = getdate(row["valid_from"])
+
+	# Find existing allowance with matching valid_from date
+	existing_allowance = next((a for a in region.allowances if getdate(a.valid_from) == row_valid_from), None)
+
+	if existing_allowance:
+		# Update valid_to if source has it but existing doesn't
+		if row["valid_to"] and not existing_allowance.valid_to:
+			existing_allowance.valid_to = row["valid_to"]
+			region.save()
+	else:
+		# Append new allowance
+		region.append(
+			"allowances",
+			{
+				"valid_from": row["valid_from"],
+				"valid_to": row.get("valid_to"),
+				"whole_day": row["whole_day"],
+				"arrival_or_departure": row["arrival_or_departure"],
+				"accommodation": row["accommodation"],
+			},
+		)
+		region.save()
 
 
 def make_property_setters():

--- a/erpnext_germany/locale/de.po
+++ b/erpnext_germany/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-20 00:48+0053\n"
+"POT-Creation-Date: 2026-01-30 16:35+0053\n"
 "PO-Revision-Date: 2025-02-20 11:46+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -18,8 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
 
-#. Label of a Currency field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Description of the 'Valid To' (Date) field in DocType 'Business Trip Region
+#. Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid ""
+"A Valid To is not needed if these rates are replaced by a row with a newer Valid From date.\n"
+"Set the Valid To date only if this region's allowance is being retired and will not be replaced by a newer rate."
+msgstr ""
+"Ein Gültig-bis-Datum ist nicht erforderlich, wenn diese Sätze durch eine Zeile mit einem neueren Gültig-ab-Datum ersetzt werden.\n"
+"Setzen Sie das Gültig-bis-Datum nur, wenn die Verpflegungspauschale dieser Region eingestellt wird und nicht durch einen neueren Satz ersetzt wird."
+
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Accommodation"
 msgstr "Unterkunft"
 
@@ -72,7 +82,9 @@ msgid "Allow deletion of the most recent record only. Applies to <b>Quotation</b
 msgstr "Falls aktiviert, kann nur die neueste Transaktion vom Typ <b>Angebot</b>, <b>Verkaufsauftrag</b> und <b>Verkaufsrechnung</b> gelöscht werden."
 
 #. Label of a Table field in DocType 'Business Trip'
+#. Label of a Table field in DocType 'Business Trip Region'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
 msgid "Allowances"
 msgstr "Verpflegungspauschalen"
 
@@ -94,19 +106,25 @@ msgid "Approved"
 msgstr "Genehmigt"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:32
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:27
 msgid "April"
 msgstr "April"
 
-#. Label of a Currency field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:37
+msgid "April - May"
+msgstr ""
+
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Arrival or Departure"
 msgstr "Ankunft oder Abreise"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:36
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:31
 msgid "August"
 msgstr "August"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:207
 msgid "Before creating a purchase invoice, please save this record."
 msgstr "Bitte speichern Sie diesen Datensatz, bevor Sie eine Eingangsrechnung erstellen."
 
@@ -183,11 +201,20 @@ msgid "Business Trip Region"
 msgstr "Dienstreise-Region"
 
 #. Name of a DocType
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid "Business Trip Region Allowance"
+msgstr "Dienstreise-Region Verpflegungspauschale"
+
+#. Name of a DocType
 #. Label of a Link in the Germany Workspace
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
 msgid "Business Trip Settings"
 msgstr "Dienstreise-Einstellungen"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:44
+msgid "Calendar Year"
+msgstr ""
 
 #: erpnext_germany/custom/sales.py:18
 msgid "Cannot delete this transaction"
@@ -220,7 +247,7 @@ msgstr "Anzahl Kinderfreibeträge"
 msgid "City"
 msgstr "Stadt"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:194
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:192
 msgid "Close"
 msgstr ""
 
@@ -231,6 +258,7 @@ msgstr ""
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:9
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:8
 msgid "Company"
 msgstr "Unternehmen"
 
@@ -325,6 +353,7 @@ msgid "Debit until {0}"
 msgstr "Soll bis {0}"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:40
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:35
 msgid "December"
 msgstr "Dezember"
 
@@ -353,12 +382,16 @@ msgstr "Deaktiviert"
 msgid "Distance"
 msgstr "Entfernung"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:141
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:139
 msgid "DocType"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:149
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:147
 msgid "Document Name"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:50
+msgid "Download CSV"
 msgstr ""
 
 #: erpnext_germany/config/desktop.py:11
@@ -419,24 +452,33 @@ msgid "Expense Claim Type for Mileage Allowance"
 msgstr "Art der Auslagenabrechnung für Kilometerpauschale"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:25
 msgid "February"
 msgstr "Februar"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:40
+msgid "First Quarter"
+msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:17
 msgid "Fiscal Year"
 msgstr "Geschäftsjahr"
 
 #. Description of the 'Whole Day' (Currency) field in DocType 'Business Trip
-#. Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "For an absence of at least 24 hours per calendar day"
 msgstr "Für eine Abwesenheit von mindestens 24 Stunden pro Kalendertag"
 
 #. Description of the 'Arrival or Departure' (Currency) field in DocType
-#. 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "For the day of arrival and departure and for an absence of more than 8 hours per calendar day"
 msgstr "Für den An- und Abreisetag und für eine Abwesenheit von mehr als 8 Stunden pro Kalendertag"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:43
+msgid "Fourth Quarter"
+msgstr ""
 
 #. Label of a Data field in DocType 'Business Trip Journey'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_journey/business_trip_journey.json
@@ -460,7 +502,7 @@ msgstr "Ab Uhrzeit"
 msgid "Germany"
 msgstr "Deutschland"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:164
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:162
 msgid "Grand Total"
 msgstr ""
 
@@ -509,8 +551,13 @@ msgid "Is Valid"
 msgstr "Ist gültig"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:29
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:24
 msgid "January"
 msgstr "Januar"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:36
+msgid "January - February"
+msgstr ""
 
 #. Label of a Table field in DocType 'Business Trip'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
@@ -518,10 +565,16 @@ msgid "Journeys"
 msgstr "Fahrten"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:35
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:30
 msgid "July"
 msgstr "Juli"
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:38
+msgid "July - August"
+msgstr ""
+
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:34
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:29
 msgid "June"
 msgstr "Juni"
 
@@ -540,7 +593,7 @@ msgstr "Verknüpftes Dokument"
 msgid "Link Title"
 msgstr "Titel des verknüpften Dokuments"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:123
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:121
 msgid "Linked Documents"
 msgstr "Verknüpfte Dokumente"
 
@@ -550,8 +603,8 @@ msgid "Load From Template"
 msgstr "Aus Vorlage laden"
 
 #. Description of the 'Accommodation' (Currency) field in DocType 'Business
-#. Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Lump sum for accommodation expenses"
 msgstr "Pauschale für Unterkunftskosten"
 
@@ -561,10 +614,12 @@ msgid "Lunch was Provided"
 msgstr "Mittagessen wurde gestellt"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:31
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:26
 msgid "March"
 msgstr "März"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:33
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:28
 msgid "May"
 msgstr "Mai"
 
@@ -586,17 +641,23 @@ msgstr "Monat"
 msgid "Nationality"
 msgstr "Nationalität"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:182
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:180
 msgid "No linked documents found."
 msgstr "Keine verknüpften Dokumente gefunden."
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:39
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:34
 msgid "November"
 msgstr "November"
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:38
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:33
 msgid "October"
 msgstr "Oktober"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:39
+msgid "October - November"
+msgstr ""
 
 #: erpnext_germany/custom/sales.py:15
 msgid "Only the most recent {0} can be deleted in order to avoid gaps in numbering."
@@ -642,15 +703,23 @@ msgstr "USt-IdNr. der Partei"
 msgid "Pay to Employee"
 msgstr "An Mitarbeiter zahlen"
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:21
+msgid "Period"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'VAT ID Check'
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:10
 msgid "Planned"
 msgstr "Geplant"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:65
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:63
 msgid "Please enter a start and end date of the trip!"
 msgstr "Bitte geben Sie das Start- und Enddatum Ihrer Reise ein!"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.py:117
+msgid "Please set a VAT ID / Tax ID in Company {0}"
+msgstr ""
 
 #. Label of a Check field in DocType 'ERPNext Germany Settings'
 #: erpnext_germany/erpnext_germany/doctype/erpnext_germany_settings/erpnext_germany_settings.json
@@ -662,7 +731,7 @@ msgstr "Lücken im Nummernkreis vermeiden"
 msgid "Preview"
 msgstr "Vorschau"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:191
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:189
 msgid "Processing Details"
 msgstr "Bearbeitungsdetails"
 
@@ -786,9 +855,13 @@ msgstr "Stammdaten-Manager Vertrieb"
 msgid "Sales User"
 msgstr "Vertriebsbenutzer"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:208
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:206
 msgid "Save Required"
 msgstr "Speichern erforderlich"
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:41
+msgid "Second Quarter"
+msgstr ""
 
 #. Label of a Column Break field in DocType 'Business Letter'
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.json
@@ -796,6 +869,7 @@ msgid "Sender"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:37
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:32
 msgid "September"
 msgstr "September"
 
@@ -809,13 +883,13 @@ msgstr "Dienst nicht verfügbar"
 msgid "Setup"
 msgstr "Einrichtung"
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:18
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:16
 msgid "Show Processing Details"
 msgstr "Bearbeitungsdetails anzeigen"
 
 #. Label of a Select field in DocType 'Business Trip'
 #. Label of a Select field in DocType 'VAT ID Check'
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:171
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:169
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 msgid "Status"
@@ -845,7 +919,7 @@ msgstr "Gebucht"
 msgid "Summen- und Saldenliste"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:155
 msgid "Supplier Name"
 msgstr ""
 
@@ -896,9 +970,17 @@ msgstr "Taxi"
 msgid "The VAT ID in {0} is invalid."
 msgstr "Die USt-IdNr. in {0} ist ungültig."
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:73
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:71
 msgid "The end date should not be before the start date!"
 msgstr "Das Enddatum darf nicht vor dem Startdatum liegen!"
+
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py:29
+msgid "There are multiple allowance rows with the same Valid From date."
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:42
+msgid "Third Quarter"
+msgstr ""
 
 #. Label of a Data field in DocType 'Business Trip'
 #. Label of a Data field in DocType 'Business Trip Region'
@@ -1000,10 +1082,15 @@ msgstr "USt-IdNr Prüfung"
 msgid "Valid"
 msgstr "Gültig"
 
-#. Label of a Date field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Label of a Date field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Valid From"
 msgstr "Gültig ab"
+
+#. Label of a Date field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid "Valid To"
+msgstr "Gültig bis"
 
 #. Label of a shortcut in the Germany Workspace
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
@@ -1011,9 +1098,9 @@ msgid "Vat Id Check"
 msgstr "USt-ID Prüfung"
 
 #. Label of a Check field in DocType 'Business Trip Allowance'
-#. Label of a Currency field in DocType 'Business Trip Region'
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Whole Day"
 msgstr "Ganztägig"
 
@@ -1021,9 +1108,20 @@ msgstr "Ganztägig"
 msgid "Working Hours Per Week"
 msgstr "Arbeitsstunden pro Woche"
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:15
+msgid "Year"
+msgstr ""
+
 #: erpnext_germany/public/js/erpnext_germany/business_letter.js:7
 msgid "You can use {0} in the Subject and Content fields for dynamic values.<br><br>All address details are available under the <code>address</code> object (e.g., <code>{{ address.city }}</code>), contact details under the <code>contact</code> object (e.g., <code>{{ contact.first_name }}</code>), and any specific information related to the dynamically linked document under the <code>reference</code> object (e.g., <code>{{ reference.some_field }}</code>).<br><br>"
 msgstr "Sie können in den Betreff- und Inhalt-Feldern {0} für dynamische Werte verwenden.<br><br>Alle Adressdetails sind unter dem <code>address</code>-Objekt verfügbar (z.B., <code>{{ address.city }}</code>), Kontaktdetails unter dem <code>contact</code>-Objekt (z.B., <code>{{ contact.first_name }}</code>), und jegliche spezifischen Informationen, die mit dem dynamisch verlinkten Dokument zusammenhängen, unter dem <code>reference</code>-Objekt (z.B., <code>{{ reference.some_field }}</code>).<br><br>"
+
+#. Name of a report
+#. Label of a Link in the Germany Workspace
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.json
+#: erpnext_germany/erpnext_germany/workspace/germany/germany.json
+msgid "Zusammenfassende Meldung"
+msgstr ""
 
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.py:49
 msgid "cancelled Business Letter {0}"
@@ -1043,9 +1141,4 @@ msgstr "Wert / Entfernung: z.B. 0,30€/km"
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
 msgid "{} Invalid"
 msgstr "{} Ungültig"
-
-#. Count format of shortcut in the Germany Workspace
-#: erpnext_germany/erpnext_germany/workspace/germany/germany.json
-msgid "{} Open"
-msgstr "{} Offen"
 

--- a/erpnext_germany/locale/main.pot
+++ b/erpnext_germany/locale/main.pot
@@ -1,14 +1,14 @@
 # Translations template for ERPNext Germany.
-# Copyright (C) 2025 ALYF GmbH
+# Copyright (C) 2026 ALYF GmbH
 # This file is distributed under the same license as the ERPNext Germany project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext Germany VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-20 00:48+0053\n"
-"PO-Revision-Date: 2025-10-20 00:48+0053\n"
+"POT-Creation-Date: 2026-01-30 16:35+0053\n"
+"PO-Revision-Date: 2026-01-30 16:35+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
 
-#. Label of a Currency field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Description of the 'Valid To' (Date) field in DocType 'Business Trip Region
+#. Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid ""
+"A Valid To is not needed if these rates are replaced by a row with a newer Valid From date.\n"
+"Set the Valid To date only if this region's allowance is being retired and will not be replaced by a newer rate."
+msgstr ""
+
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Accommodation"
 msgstr ""
 
@@ -70,7 +78,9 @@ msgid "Allow deletion of the most recent record only. Applies to <b>Quotation</b
 msgstr ""
 
 #. Label of a Table field in DocType 'Business Trip'
+#. Label of a Table field in DocType 'Business Trip Region'
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
 msgid "Allowances"
 msgstr ""
 
@@ -92,19 +102,25 @@ msgid "Approved"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:32
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:27
 msgid "April"
 msgstr ""
 
-#. Label of a Currency field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:37
+msgid "April - May"
+msgstr ""
+
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Arrival or Departure"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:36
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:31
 msgid "August"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:209
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:207
 msgid "Before creating a purchase invoice, please save this record."
 msgstr ""
 
@@ -181,10 +197,19 @@ msgid "Business Trip Region"
 msgstr ""
 
 #. Name of a DocType
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid "Business Trip Region Allowance"
+msgstr ""
+
+#. Name of a DocType
 #. Label of a Link in the Germany Workspace
 #: erpnext_germany/erpnext_germany/doctype/business_trip_settings/business_trip_settings.json
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
 msgid "Business Trip Settings"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:44
+msgid "Calendar Year"
 msgstr ""
 
 #: erpnext_germany/custom/sales.py:18
@@ -218,7 +243,7 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:194
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:192
 msgid "Close"
 msgstr ""
 
@@ -229,6 +254,7 @@ msgstr ""
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:9
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:8
 msgid "Company"
 msgstr ""
 
@@ -323,6 +349,7 @@ msgid "Debit until {0}"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:40
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:35
 msgid "December"
 msgstr ""
 
@@ -351,12 +378,16 @@ msgstr ""
 msgid "Distance"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:141
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:139
 msgid "DocType"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:149
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:147
 msgid "Document Name"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:50
+msgid "Download CSV"
 msgstr ""
 
 #: erpnext_germany/config/desktop.py:11
@@ -417,7 +448,12 @@ msgid "Expense Claim Type for Mileage Allowance"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:30
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:25
 msgid "February"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:40
+msgid "First Quarter"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:17
@@ -425,15 +461,19 @@ msgid "Fiscal Year"
 msgstr ""
 
 #. Description of the 'Whole Day' (Currency) field in DocType 'Business Trip
-#. Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "For an absence of at least 24 hours per calendar day"
 msgstr ""
 
 #. Description of the 'Arrival or Departure' (Currency) field in DocType
-#. 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "For the day of arrival and departure and for an absence of more than 8 hours per calendar day"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:43
+msgid "Fourth Quarter"
 msgstr ""
 
 #. Label of a Data field in DocType 'Business Trip Journey'
@@ -458,7 +498,7 @@ msgstr ""
 msgid "Germany"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:164
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:162
 msgid "Grand Total"
 msgstr ""
 
@@ -507,7 +547,12 @@ msgid "Is Valid"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:29
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:24
 msgid "January"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:36
+msgid "January - February"
 msgstr ""
 
 #. Label of a Table field in DocType 'Business Trip'
@@ -516,10 +561,16 @@ msgid "Journeys"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:35
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:30
 msgid "July"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:38
+msgid "July - August"
+msgstr ""
+
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:34
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:29
 msgid "June"
 msgstr ""
 
@@ -538,7 +589,7 @@ msgstr ""
 msgid "Link Title"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:123
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:121
 msgid "Linked Documents"
 msgstr ""
 
@@ -548,8 +599,8 @@ msgid "Load From Template"
 msgstr ""
 
 #. Description of the 'Accommodation' (Currency) field in DocType 'Business
-#. Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Lump sum for accommodation expenses"
 msgstr ""
 
@@ -559,10 +610,12 @@ msgid "Lunch was Provided"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:31
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:26
 msgid "March"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:33
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:28
 msgid "May"
 msgstr ""
 
@@ -584,16 +637,22 @@ msgstr ""
 msgid "Nationality"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:182
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:180
 msgid "No linked documents found."
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:39
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:34
 msgid "November"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:38
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:33
 msgid "October"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:39
+msgid "October - November"
 msgstr ""
 
 #: erpnext_germany/custom/sales.py:15
@@ -640,14 +699,22 @@ msgstr ""
 msgid "Pay to Employee"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:21
+msgid "Period"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'VAT ID Check'
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check_list.js:10
 msgid "Planned"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:65
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:63
 msgid "Please enter a start and end date of the trip!"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.py:117
+msgid "Please set a VAT ID / Tax ID in Company {0}"
 msgstr ""
 
 #. Label of a Check field in DocType 'ERPNext Germany Settings'
@@ -660,7 +727,7 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:191
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:189
 msgid "Processing Details"
 msgstr ""
 
@@ -784,8 +851,12 @@ msgstr ""
 msgid "Sales User"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:208
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:206
 msgid "Save Required"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:41
+msgid "Second Quarter"
 msgstr ""
 
 #. Label of a Column Break field in DocType 'Business Letter'
@@ -794,6 +865,7 @@ msgid "Sender"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/report/summen__und_saldenliste/summen__und_saldenliste.js:37
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:32
 msgid "September"
 msgstr ""
 
@@ -807,13 +879,13 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:18
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:16
 msgid "Show Processing Details"
 msgstr ""
 
 #. Label of a Select field in DocType 'Business Trip'
 #. Label of a Select field in DocType 'VAT ID Check'
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:171
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:169
 #: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.json
 #: erpnext_germany/erpnext_germany/doctype/vat_id_check/vat_id_check.json
 msgid "Status"
@@ -843,7 +915,7 @@ msgstr ""
 msgid "Summen- und Saldenliste"
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:157
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:155
 msgid "Supplier Name"
 msgstr ""
 
@@ -894,8 +966,16 @@ msgstr ""
 msgid "The VAT ID in {0} is invalid."
 msgstr ""
 
-#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:73
+#: erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.js:71
 msgid "The end date should not be before the start date!"
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.py:29
+msgid "There are multiple allowance rows with the same Valid From date."
+msgstr ""
+
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:42
+msgid "Third Quarter"
 msgstr ""
 
 #. Label of a Data field in DocType 'Business Trip'
@@ -998,9 +1078,14 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#. Label of a Date field in DocType 'Business Trip Region'
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#. Label of a Date field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Valid From"
+msgstr ""
+
+#. Label of a Date field in DocType 'Business Trip Region Allowance'
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
+msgid "Valid To"
 msgstr ""
 
 #. Label of a shortcut in the Germany Workspace
@@ -1009,9 +1094,9 @@ msgid "Vat Id Check"
 msgstr ""
 
 #. Label of a Check field in DocType 'Business Trip Allowance'
-#. Label of a Currency field in DocType 'Business Trip Region'
+#. Label of a Currency field in DocType 'Business Trip Region Allowance'
 #: erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.json
-#: erpnext_germany/erpnext_germany/doctype/business_trip_region/business_trip_region.json
+#: erpnext_germany/erpnext_germany/doctype/business_trip_region_allowance/business_trip_region_allowance.json
 msgid "Whole Day"
 msgstr ""
 
@@ -1019,8 +1104,19 @@ msgstr ""
 msgid "Working Hours Per Week"
 msgstr ""
 
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.js:15
+msgid "Year"
+msgstr ""
+
 #: erpnext_germany/public/js/erpnext_germany/business_letter.js:7
 msgid "You can use {0} in the Subject and Content fields for dynamic values.<br><br>All address details are available under the <code>address</code> object (e.g., <code>{{ address.city }}</code>), contact details under the <code>contact</code> object (e.g., <code>{{ contact.first_name }}</code>), and any specific information related to the dynamically linked document under the <code>reference</code> object (e.g., <code>{{ reference.some_field }}</code>).<br><br>"
+msgstr ""
+
+#. Name of a report
+#. Label of a Link in the Germany Workspace
+#: erpnext_germany/erpnext_germany/report/zusammenfassende_meldung/zusammenfassende_meldung.json
+#: erpnext_germany/erpnext_germany/workspace/germany/germany.json
+msgid "Zusammenfassende Meldung"
 msgstr ""
 
 #: erpnext_germany/erpnext_germany/doctype/business_letter/business_letter.py:49
@@ -1040,10 +1136,5 @@ msgstr ""
 #. Count format of shortcut in the Germany Workspace
 #: erpnext_germany/erpnext_germany/workspace/germany/germany.json
 msgid "{} Invalid"
-msgstr ""
-
-#. Count format of shortcut in the Germany Workspace
-#: erpnext_germany/erpnext_germany/workspace/germany/germany.json
-msgid "{} Open"
 msgstr ""
 

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -7,7 +7,7 @@ execute:from erpnext_germany.install import insert_custom_records; insert_custom
 erpnext_germany.patches.change_position_of_register_info
 erpnext_germany.patches.dynamic_party_in_vat_id_check
 erpnext_germany.patches.add_business_trip_to_expense_claim
-erpnext_germany.patches.import_business_trip_regions
+erpnext_germany.patches.import_business_trip_regions # 2026-01-30
 execute:from erpnext_germany.install import make_custom_fields; make_custom_fields() # 2025-12-12
 execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming", 1)
 erpnext_germany.patches.set_business_trip_settings

--- a/erpnext_germany/patches.txt
+++ b/erpnext_germany/patches.txt
@@ -7,10 +7,10 @@ execute:from erpnext_germany.install import insert_custom_records; insert_custom
 erpnext_germany.patches.change_position_of_register_info
 erpnext_germany.patches.dynamic_party_in_vat_id_check
 erpnext_germany.patches.add_business_trip_to_expense_claim
-erpnext_germany.patches.import_business_trip_regions # 2026-01-30
 execute:from erpnext_germany.install import make_custom_fields; make_custom_fields() # 2025-12-12
 execute:frappe.db.set_single_value("ERPNext Germany Settings", "prevent_gaps_in_transaction_naming", 1)
 erpnext_germany.patches.set_business_trip_settings
 erpnext_germany.patches.remove_some_employee_property_setters
 execute:from erpnext_germany.install import make_property_setters; make_property_setters()
 erpnext_germany.patches.move_business_trip_region_data_to_child_table #2
+erpnext_germany.patches.import_business_trip_regions # 2026-01-30

--- a/erpnext_germany/patches/import_business_trip_regions.py
+++ b/erpnext_germany/patches/import_business_trip_regions.py
@@ -1,7 +1,11 @@
 from frappe import get_app_path
 
-from erpnext_germany.install import import_csv
+from erpnext_germany.install import business_trip_region_csv_import, import_csv
 
 
 def execute():
-	import_csv("Business Trip Region", get_app_path("erpnext_germany", "data", "business_trip_region.csv"))
+	import_csv(
+		"Business Trip Region",
+		get_app_path("erpnext_germany", "data", "business_trip_region.csv"),
+		business_trip_region_csv_import,
+	)

--- a/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
+++ b/erpnext_germany/patches/move_business_trip_region_data_to_child_table.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils.data import getdate
 
 
 def execute():
@@ -9,7 +10,11 @@ def execute():
 	for business_trip_region_id in regions:
 		doc = frappe.get_doc("Business Trip Region", business_trip_region_id)
 
-		# Step 1: Move the data to the child table.
+		if getdate(doc.valid_from or "2000-01-01") in {
+			getdate(allowance.valid_from) for allowance in doc.allowances
+		}:
+			continue
+
 		doc.append(
 			"allowances",
 			{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,9 @@
-import globals from "globals";
-import js from "@eslint/js";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+// Use CJS resolver so pre-commit NODE_PATH is honored.
+const globals = require("globals");
+const js = require("@eslint/js");
 
 export default [
 	js.configs.recommended,


### PR DESCRIPTION
- Add an optional _Valid To_ field in **Business Trip Region**'s _Allowances_ table

    Through new regulations, former regions might get dropped or re-added after a pause. Hence we need a way to disable them _for a certain period_.

- Adjust the install script to import data into the child table format for allowances that has been introduced in #106
- Update the regional allowance CSV with the [latest data from 2026](https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Steuerarten/Lohnsteuer/2025-12-05-steuerliche-behandlung-reisekosten-2026.pdf?__blob=publicationFile&v=4), run patch

Note: the query in **Business Trip** doesn't yet consider the _Valid To_ field. Users can still select an invalid record, but the calculated allowance will be zero.  