### PR TITLE
fix(Business Trip): no allowance for single-day trip with less than 8h

### DIFF
--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import frappe
 from frappe import get_installed_apps
 from frappe.model.document import Document
-from frappe.utils.data import fmt_money
+from frappe.utils.data import fmt_money, get_time
 
 DEFAULT_EXPENSE_CLAIM_TYPE = "Additional meal expenses"
+ONE_DAY_TRIP_MINIMUM_HOURS = 8
 
 if TYPE_CHECKING:
 	from erpnext_germany.erpnext_germany.doctype.business_trip_settings.business_trip_settings import (
@@ -72,6 +74,8 @@ class BusinessTrip(Document):
 		if not self.region:
 			return
 
+		is_overnight_trip = bool(self.from_date != self.to_date)
+
 		for allowance in self.allowances:
 			whole_day = 0.0
 			arrival_or_departure = 0.0
@@ -97,6 +101,17 @@ class BusinessTrip(Document):
 
 			if not allowance.accommodation_was_provided:
 				amount += accommodation
+
+			# One-day trip (no overnight): 8-hour minimum for arrival/departure allowance.
+			# Multi-day with overnight: full small rate for arrival/departure day regardless of hours.
+			if not allowance.whole_day and not is_overnight_trip:
+				t_from = get_time(allowance.from_time)
+				t_to = get_time(allowance.to_time)
+				duration_hours = (
+					datetime.combine(date.min, t_to) - datetime.combine(date.min, t_from)
+				).total_seconds() / 3600
+				if duration_hours < ONE_DAY_TRIP_MINIMUM_HOURS:
+					amount = 0.0
 
 			allowance.amount = max(amount, 0.0)
 
@@ -279,10 +294,6 @@ def _get_allowance_rates(region: str, date: str):
 			"parent": region,
 			"valid_from": ["<=", date],
 		},
-		or_filters=[
-			["valid_to", "is", "not set"],
-			["valid_to", ">=", date],
-		],
 		order_by="valid_from DESC",
 		fields=["valid_from", "whole_day", "arrival_or_departure", "accommodation"],
 	)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -73,7 +73,7 @@ class BusinessTrip(Document):
 		if not self.region:
 			return
 
-		is_multiday_trip = bool(self.from_date != self.to_date)
+		is_multiday_trip = self.from_date != self.to_date
 
 		for allowance in self.allowances:
 			whole_day = 0.0

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -294,6 +294,10 @@ def _get_allowance_rates(region: str, date: str):
 			"parent": region,
 			"valid_from": ["<=", date],
 		},
+		or_filters=[
+			["valid_to", "is", "not set"],
+			["valid_to", ">=", date],
+		],
 		order_by="valid_from DESC",
 		fields=["valid_from", "whole_day", "arrival_or_departure", "accommodation"],
 	)

--- a/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip/business_trip.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
-from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import frappe
 from frappe import get_installed_apps
 from frappe.model.document import Document
-from frappe.utils.data import fmt_money, get_time
+from frappe.utils.data import fmt_money
 
 DEFAULT_EXPENSE_CLAIM_TYPE = "Additional meal expenses"
 ONE_DAY_TRIP_MINIMUM_HOURS = 8
@@ -74,7 +73,7 @@ class BusinessTrip(Document):
 		if not self.region:
 			return
 
-		is_overnight_trip = bool(self.from_date != self.to_date)
+		is_multiday_trip = bool(self.from_date != self.to_date)
 
 		for allowance in self.allowances:
 			whole_day = 0.0
@@ -103,15 +102,9 @@ class BusinessTrip(Document):
 				amount += accommodation
 
 			# One-day trip (no overnight): 8-hour minimum for arrival/departure allowance.
-			# Multi-day with overnight: full small rate for arrival/departure day regardless of hours.
-			if not allowance.whole_day and not is_overnight_trip:
-				t_from = get_time(allowance.from_time)
-				t_to = get_time(allowance.to_time)
-				duration_hours = (
-					datetime.combine(date.min, t_to) - datetime.combine(date.min, t_from)
-				).total_seconds() / 3600
-				if duration_hours < ONE_DAY_TRIP_MINIMUM_HOURS:
-					amount = 0.0
+			# First day of multi-day trip: rate for arrival/departure regardless of hours.
+			if not is_multiday_trip and not allowance.is_longer_than(ONE_DAY_TRIP_MINIMUM_HOURS):
+				amount = 0.0
 
 			allowance.amount = max(amount, 0.0)
 

--- a/erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.py
+++ b/erpnext_germany/erpnext_germany/doctype/business_trip_allowance/business_trip_allowance.py
@@ -2,7 +2,10 @@
 # For license information, please see license.txt
 
 # import frappe
+from datetime import datetime
+
 from frappe.model.document import Document
+from frappe.utils.data import get_time, getdate
 
 
 class BusinessTripAllowance(Document):
@@ -27,4 +30,19 @@ class BusinessTripAllowance(Document):
 		to_time: DF.Time | None
 		whole_day: DF.Check
 	# end: auto-generated types
-	pass
+
+	def is_longer_than(self, hours: float) -> bool:
+		if self.whole_day:
+			duration_hours = 24
+		else:
+			cur_date = getdate(self.date)
+			duration_hours = get_duration_hours(
+				from_datetime=datetime.combine(cur_date, get_time(self.from_time)),
+				to_datetime=datetime.combine(cur_date, get_time(self.to_time)),
+			)
+
+		return duration_hours > hours
+
+
+def get_duration_hours(from_datetime: datetime, to_datetime: datetime) -> float:
+	return (to_datetime - from_datetime).total_seconds() / 3600


### PR DESCRIPTION
Following regulatory rule was not implemented:
If a travel day has less than 8hrs, the employee is not granted allowances.
Exemption of that rule: Multi-day trips (example: An employee starts to travel at 18:00 to a hotel, where he stays for a few days).